### PR TITLE
KTO-130 kouta-backend testien nopeuttaminen

### DIFF
--- a/src/main/scala/fi/oph/kouta/indexing/sqsQueue.scala
+++ b/src/main/scala/fi/oph/kouta/indexing/sqsQueue.scala
@@ -65,7 +65,9 @@ object SqsService extends Logging {
   }
 }
 
-object SqsInTransactionService extends Logging {
+object SqsInTransactionService extends SqsInTransactionService
+
+abstract class SqsInTransactionService extends Logging {
 
   import slick.dbio.DBIO
   import fi.oph.kouta.repository.KoutaDatabase

--- a/src/main/scala/fi/oph/kouta/servlet/HakuServlet.scala
+++ b/src/main/scala/fi/oph/kouta/servlet/HakuServlet.scala
@@ -6,16 +6,18 @@ import fi.oph.kouta.service.HakuService
 import org.scalatra.{NotFound, Ok}
 import org.scalatra.swagger.Swagger
 
-class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
+class HakuServlet(hakuService: HakuService)(implicit val swagger:Swagger) extends KoutaServlet {
   override val modelName: String = "Haku"
   override val applicationDescription = "Hakujen API"
+
+  def this()(implicit swagger:Swagger) = this(HakuService)
 
   get("/:oid", operation(apiOperation[Haku]("Hae haku")
     tags modelName
     summary "Hae haku"
     parameter pathParam[String]("oid").description("Haun oid"))) {
 
-    HakuService.get(HakuOid(params("oid"))) match {
+    hakuService.get(HakuOid(params("oid"))) match {
       case None => NotFound("error" -> "Unknown haku oid")
       case Some((k, l)) => Ok(k, headers = Map("Last-Modified" -> createLastModifiedHeader(l)))
     }
@@ -26,7 +28,7 @@ class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
     summary "Tallenna uusi haku"
     parameter bodyParam[Haku])) {
 
-    HakuService.put(parsedBody.extract[Haku]) match {
+    hakuService.put(parsedBody.extract[Haku]) match {
       case oid => Ok("oid" -> oid)
     }
   }
@@ -36,7 +38,7 @@ class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
     summary "Muokkaa olemassa olevaa hakua"
     parameter bodyParam[Haku])) {
 
-    HakuService.update(parsedBody.extract[Haku], getIfUnmodifiedSince) match {
+    hakuService.update(parsedBody.extract[Haku], getIfUnmodifiedSince) match {
       case updated => Ok("updated" -> updated)
     }
   }
@@ -47,7 +49,7 @@ class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
     parameter queryParam[String]("organisaatioOid").description(s"Käyttäjän organisaation oid (TODO: tulee tulevaisuudessa CASista)"))) {
     params.get("organisaatioOid").map(OrganisaatioOid) match {
       case None => NotFound()
-      case Some(oid) => Ok(HakuService.list(oid))
+      case Some(oid) => Ok(hakuService.list(oid))
     }
   }
 
@@ -57,8 +59,8 @@ class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
     parameter pathParam[String]("oid").description("Haun oid")
     parameter queryParam[String]("organisaatioOid").description("Organisaation oid"))) {
     params.get("organisaatioOid").map(OrganisaatioOid) match {
-      case None => Ok(HakuService.listHakukohteet(HakuOid(params("oid")))) //TODO: Vain oph/indeksoija saa nähdä kaiken. Koskee myös muiden servletien vastaavia rajapintoja.
-      case Some(organisaatioOid) => Ok(HakuService.listHakukohteet(HakuOid(params("oid")), organisaatioOid))
+      case None => Ok(hakuService.listHakukohteet(HakuOid(params("oid")))) //TODO: Vain oph/indeksoija saa nähdä kaiken. Koskee myös muiden servletien vastaavia rajapintoja.
+      case Some(organisaatioOid) => Ok(hakuService.listHakukohteet(HakuOid(params("oid")), organisaatioOid))
     }
   }
   get("/:oid/koulutukset/list", operation(apiOperation[List[KoulutusListItem]]("Listaa hakuun liittyvät koulutukset")
@@ -66,7 +68,7 @@ class HakuServlet (implicit val swagger:Swagger) extends KoutaServlet {
     summary "Listaa hakuun liittyvät koulutukset"
     parameter pathParam[String]("oid").description("Haun oid"))) {
 
-    Ok(HakuService.listKoulutukset(HakuOid(params("oid"))))
+    Ok(hakuService.listKoulutukset(HakuOid(params("oid"))))
   }
 
   prettifySwaggerModels()

--- a/src/main/scala/fi/oph/kouta/servlet/HakukohdeServlet.scala
+++ b/src/main/scala/fi/oph/kouta/servlet/HakukohdeServlet.scala
@@ -6,7 +6,7 @@ import fi.oph.kouta.service.HakukohdeService
 import org.scalatra.{NotFound, Ok}
 import org.scalatra.swagger.Swagger
 
-class HakukohdeServlet(hakukohdeService: HakukohdeService) (implicit val swagger:Swagger) extends KoutaServlet {
+class HakukohdeServlet(hakukohdeService: HakukohdeService)(implicit val swagger:Swagger) extends KoutaServlet {
   override val modelName: String = "Hakukohde"
   override val applicationDescription = "Hakukohteiden API"
 

--- a/src/main/scala/fi/oph/kouta/servlet/HakukohdeServlet.scala
+++ b/src/main/scala/fi/oph/kouta/servlet/HakukohdeServlet.scala
@@ -6,16 +6,18 @@ import fi.oph.kouta.service.HakukohdeService
 import org.scalatra.{NotFound, Ok}
 import org.scalatra.swagger.Swagger
 
-class HakukohdeServlet (implicit val swagger:Swagger) extends KoutaServlet {
+class HakukohdeServlet(hakukohdeService: HakukohdeService) (implicit val swagger:Swagger) extends KoutaServlet {
   override val modelName: String = "Hakukohde"
   override val applicationDescription = "Hakukohteiden API"
+
+  def this()(implicit swagger: Swagger) = this(HakukohdeService)
 
   get("/:oid", operation(apiOperation[Hakukohde]("Hae hakukohde")
     tags modelName
     summary "Hae hakukohde"
     parameter pathParam[String]("oid").description("Hakukohteen oid"))) {
 
-    HakukohdeService.get(HakukohdeOid(params("oid"))) match {
+    hakukohdeService.get(HakukohdeOid(params("oid"))) match {
       case None => NotFound("error" -> "Unknown hakukohde oid")
       case Some((k, l)) => Ok(k, headers = Map("Last-Modified" -> createLastModifiedHeader(l)))
     }
@@ -26,7 +28,7 @@ class HakukohdeServlet (implicit val swagger:Swagger) extends KoutaServlet {
     summary "Tallenna uusi hakukohde"
     parameter bodyParam[Hakukohde])) {
 
-    HakukohdeService.put(parsedBody.extract[Hakukohde]) match {
+    hakukohdeService.put(parsedBody.extract[Hakukohde]) match {
       case oid => Ok("oid" -> oid)
     }
   }
@@ -36,7 +38,7 @@ class HakukohdeServlet (implicit val swagger:Swagger) extends KoutaServlet {
     summary "Muokkaa olemassa olevaa hakukohdetta"
     parameter bodyParam[Hakukohde])) {
 
-    HakukohdeService.update(parsedBody.extract[Hakukohde], getIfUnmodifiedSince) match {
+    hakukohdeService.update(parsedBody.extract[Hakukohde], getIfUnmodifiedSince) match {
       case updated => Ok("updated" -> updated)
     }
   }

--- a/src/main/scala/fi/oph/kouta/servlet/ToteutusServlet.scala
+++ b/src/main/scala/fi/oph/kouta/servlet/ToteutusServlet.scala
@@ -6,16 +6,18 @@ import fi.oph.kouta.service.ToteutusService
 import org.scalatra.{NotFound, Ok}
 import org.scalatra.swagger.Swagger
 
-class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
+class ToteutusServlet(toteutusService: ToteutusService)(implicit val swagger: Swagger) extends KoutaServlet {
   override val applicationDescription = "Koulutusten toteutusten API"
   override val modelName = "Toteutus"
+
+  def this()(implicit swagger: Swagger) = this(ToteutusService)
 
   get("/:oid", operation(apiOperation[Toteutus]("Hae toteutus")
     tags modelName
     summary "Hae toteutus"
     parameter pathParam[String]("oid").description("Toteutuksen oid"))) {
 
-    ToteutusService.get(ToteutusOid(params("oid"))) match {
+    toteutusService.get(ToteutusOid(params("oid"))) match {
       case None => NotFound("error" -> "Unknown toteutus oid")
       case Some((k, l)) => Ok(k, headers = Map("Last-Modified" -> createLastModifiedHeader(l)))
     }
@@ -26,7 +28,7 @@ class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Tallenna uusi toteutus"
     parameter bodyParam[Toteutus])) {
 
-    ToteutusService.put(parsedBody.extract[Toteutus]) match {
+    toteutusService.put(parsedBody.extract[Toteutus]) match {
       case oid => Ok("oid" -> oid)
     }
   }
@@ -36,7 +38,7 @@ class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Muokkaa olemassa olevaa toteutusta"
     parameter bodyParam[Toteutus])) {
 
-    ToteutusService.update(parsedBody.extract[Toteutus], getIfUnmodifiedSince) match {
+    toteutusService.update(parsedBody.extract[Toteutus], getIfUnmodifiedSince) match {
       case updated => Ok("updated" -> updated)
     }
   }
@@ -47,7 +49,7 @@ class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
     parameter queryParam[String]("organisaatioOid").description(s"Käyttäjän organisaation oid (TODO: tulee tulevaisuudessa CASista)"))) {
     params.get("organisaatioOid").map(OrganisaatioOid) match {
       case None => NotFound()
-      case Some(oid) => Ok(ToteutusService.list(oid))
+      case Some(oid) => Ok(toteutusService.list(oid))
     }
   }
 
@@ -55,7 +57,7 @@ class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
     tags modelName
     summary "Listaa toteutukseen liitetyt haut"
     parameter pathParam[String]("oid").description("Toteutuksen oid"))) {
-    Ok(ToteutusService.listHaut(ToteutusOid(params("oid"))))
+    Ok(toteutusService.listHaut(ToteutusOid(params("oid"))))
   }
 
   get("/:oid/hakukohteet/list", operation(apiOperation[List[HakukohdeListItem]]("Listaa toteutukseen liitetyt hakukohteet")
@@ -63,7 +65,7 @@ class ToteutusServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Listaa toteutukseen liitetyt hakukohteet"
     parameter pathParam[String]("oid").description("Toteutuksen oid"))) {
 
-    Ok(ToteutusService.listHakukohteet(ToteutusOid(params("oid"))))
+    Ok(toteutusService.listHakukohteet(ToteutusOid(params("oid"))))
   }
 
   prettifySwaggerModels()

--- a/src/main/scala/fi/oph/kouta/servlet/ValintaperusteServlet.scala
+++ b/src/main/scala/fi/oph/kouta/servlet/ValintaperusteServlet.scala
@@ -8,16 +8,18 @@ import fi.oph.kouta.service.ValintaperusteService
 import org.scalatra.swagger.Swagger
 import org.scalatra.{NotFound, Ok}
 
-class ValintaperusteServlet(implicit val swagger:Swagger) extends KoutaServlet {
+class ValintaperusteServlet(valintaperusteService: ValintaperusteService)(implicit val swagger: Swagger) extends KoutaServlet {
   override val applicationDescription = "Valintaperustekuvausten API"
   override val modelName = "Valintaperuste"
+
+  def this()(implicit swagger: Swagger) = this(ValintaperusteService)
 
   get("/:id", operation(apiOperation[Valintaperuste]("Hae valintaperuste")
     tags modelName
     summary "Hae valintaperuste"
     parameter pathParam[String]("id").description("Valintaperusteen UUID"))) {
 
-    ValintaperusteService.get(UUID.fromString(params("id"))) match {
+    valintaperusteService.get(UUID.fromString(params("id"))) match {
       case None => NotFound("error" -> "Unknown valintaperuste id")
       case Some((k, l)) => Ok(k, headers = Map("Last-Modified" -> createLastModifiedHeader(l)))
     }
@@ -28,7 +30,7 @@ class ValintaperusteServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Tallenna uusi valintaperuste"
     parameter bodyParam[Valintaperuste])) {
 
-    ValintaperusteService.put(parsedBody.extract[Valintaperuste]) match {
+    valintaperusteService.put(parsedBody.extract[Valintaperuste]) match {
       case id => Ok("id" -> id)
     }
   }
@@ -38,7 +40,7 @@ class ValintaperusteServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Muokkaa olemassa olevaa valintaperusteta"
     parameter bodyParam[Valintaperuste])) {
 
-    ValintaperusteService.update(parsedBody.extract[Valintaperuste], getIfUnmodifiedSince) match {
+    valintaperusteService.update(parsedBody.extract[Valintaperuste], getIfUnmodifiedSince) match {
       case updated => Ok("updated" -> updated)
     }
   }
@@ -50,8 +52,8 @@ class ValintaperusteServlet(implicit val swagger:Swagger) extends KoutaServlet {
     parameter queryParam[String]("hakuOid").description(s"Haun oid"))) {
     ( params.get("organisaatioOid"), params.get("hakuOid") ) match {
       case (None, _) => NotFound()
-      case (Some(oid), None) => Ok(ValintaperusteService.list(OrganisaatioOid(oid)))
-      case (Some(oid), Some(hakuOid)) => Ok(ValintaperusteService.listByHaunKohdejoukko(OrganisaatioOid(oid), HakuOid(hakuOid)))
+      case (Some(oid), None) => Ok(valintaperusteService.list(OrganisaatioOid(oid)))
+      case (Some(oid), Some(hakuOid)) => Ok(valintaperusteService.listByHaunKohdejoukko(OrganisaatioOid(oid), HakuOid(hakuOid)))
     }
   }
 
@@ -60,7 +62,7 @@ class ValintaperusteServlet(implicit val swagger:Swagger) extends KoutaServlet {
     summary "Listaa kaikki hakukohteet, jotka käyttävät annettua valintaperustekuvausta"
     parameter pathParam[String]("id").description("Valintaperusteen UUID"))) {
 
-    Ok(ValintaperusteService.listByValintaperusteId(UUID.fromString(params("id"))))
+    Ok(valintaperusteService.listByValintaperusteId(UUID.fromString(params("id"))))
   }
 
   prettifySwaggerModels()

--- a/src/test/scala/fi/oph/kouta/SqsInTransactionServiceIgnoringIndexing.scala
+++ b/src/test/scala/fi/oph/kouta/SqsInTransactionServiceIgnoringIndexing.scala
@@ -1,0 +1,14 @@
+package fi.oph.kouta
+
+import fi.oph.kouta.indexing.SqsInTransactionService
+import fi.oph.kouta.indexing.indexing.{IndexType, Priority}
+import fi.oph.kouta.repository.KoutaDatabase
+import slick.dbio.DBIO
+
+object SqsInTransactionServiceIgnoringIndexing extends SqsInTransactionService {
+  override def runActionAndUpdateIndex[R](priority: Priority,
+                                          index: IndexType,
+                                          action: () => DBIO[R],
+                                          getIndexableValue: R => String): R =
+    KoutaDatabase.runBlockingTransactionally(action()).get
+}

--- a/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -6,8 +6,7 @@ import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.fixture.HakuFixture
 import fi.oph.kouta.validation.Validations
 
-class HakuSpec extends KoutaIntegrationSpec
-  with HakuFixture with Validations with KonfoIndexingQueues with EventuallyMessages {
+class HakuSpec extends KoutaIntegrationSpec with HakuFixture with Validations {
 
   it should "return 404 if haku not found" in {
     get("/haku/123") {
@@ -129,19 +128,5 @@ class HakuSpec extends KoutaIntegrationSpec
     val lastModified = get(oid, haku(oid))
     update(haku(oid).copy(hakuajat = List()), lastModified)
     get(oid, haku(oid).copy(hakuajat = List()))
-  }
-
-  it should "send indexing message after creating haku" in {
-    val oid = put(haku)
-    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
-  }
-
-  it should "send indexing message after updating haku" in {
-    val oid = put(haku)
-    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
-
-    update(haku(oid, Arkistoitu), lastModified = get(oid, haku(oid)))
-
-    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
   }
 }

--- a/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -1,6 +1,6 @@
 package fi.oph.kouta.integration
 
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues, TestData}
+import fi.oph.kouta.TestData
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.fixture.HakuFixture

--- a/src/test/scala/fi/oph/kouta/integration/HakukohdeSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/HakukohdeSpec.scala
@@ -2,10 +2,9 @@ package fi.oph.kouta.integration
 
 import java.util.UUID
 
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues, TestData}
+import fi.oph.kouta.TestData
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
-import fi.oph.kouta.repository.SQLHelpers
 import fi.oph.kouta.validation.Validations
 
 class HakukohdeSpec extends KoutaIntegrationSpec with EverythingFixture with Validations {

--- a/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
@@ -79,14 +79,14 @@ class IndexingSpec extends KoutaIntegrationSpec
     eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$id"]}""") }
   }
 
-  it should "send indexing message after creating hakukohde" in {
+  "Create hakukohde" should "send indexing message after creating hakukohde" in {
     val oid = put(uusiHakukohde)
     eventuallyIndexingMessages {
       _ should contain(s"""{"hakukohteet":["$oid"]}""")
     }
   }
 
-  it should "send indexing message after updating hakukohde" in {
+  "Update hakukohde" should "send indexing message after updating hakukohde" in {
     val oid = put(uusiHakukohde)
     eventuallyIndexingMessages {
       _ should contain(s"""{"hakukohteet":["$oid"]}""")

--- a/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
@@ -1,17 +1,12 @@
 package fi.oph.kouta.integration
 
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 import fi.oph.kouta.domain.Arkistoitu
-import fi.oph.kouta.integration.fixture.HakuFixture
-import fi.oph.kouta.servlet.HakuServlet
+import fi.oph.kouta.integration.fixture.EverythingFixtureWithIndexing
 import fi.oph.kouta.validation.Validations
-
-trait HakuFixtureWithIndexing extends HakuFixture { this: KoutaIntegrationSpec =>
-  override def init(): Unit = addServlet(new HakuServlet(), HakuPath)
-}
+import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 
 class IndexingSpec extends KoutaIntegrationSpec
-  with HakuFixtureWithIndexing with Validations with KonfoIndexingQueues with EventuallyMessages {
+  with EverythingFixtureWithIndexing with Validations with KonfoIndexingQueues with EventuallyMessages {
 
   "Create haku" should "send indexing message after creating haku" in {
     val oid = put(haku)
@@ -25,5 +20,38 @@ class IndexingSpec extends KoutaIntegrationSpec
     update(haku(oid, Arkistoitu), lastModified = get(oid, haku(oid)))
 
     eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
+  }
+
+  "Create koulutus" should "send indexing message after creating koulutus" in {
+    val oid = put(koulutus)
+    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
+  }
+
+  "Update koulutus" should "send indexing message after updating koulutus" in {
+    val oid = put(koulutus)
+    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
+
+    update(koulutus(oid, Arkistoitu), lastModified = get(oid, koulutus(oid)))
+
+    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
+  }
+
+  "Create toteutus" should "send indexing message after creating toteutus" in {
+    val koulutusOid = put(koulutus)
+    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$koulutusOid"]}""") }
+
+    val oid = put(toteutus(koulutusOid))
+    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
+  }
+
+  "Update toteutus" should "send indexing message after updating toteutus" in {
+    val koulutusOid = put(koulutus)
+    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$koulutusOid"]}""") }
+
+    val oid = put(toteutus(koulutusOid))
+    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
+
+    update(toteutus(oid, koulutusOid, Arkistoitu), lastModified = get(oid, toteutus(oid, koulutusOid)))
+    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
   }
 }

--- a/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
@@ -1,0 +1,29 @@
+package fi.oph.kouta.integration
+
+import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
+import fi.oph.kouta.domain.Arkistoitu
+import fi.oph.kouta.integration.fixture.HakuFixture
+import fi.oph.kouta.servlet.HakuServlet
+import fi.oph.kouta.validation.Validations
+
+trait HakuFixtureWithIndexing extends HakuFixture { this: KoutaIntegrationSpec =>
+  override def init(): Unit = addServlet(new HakuServlet(), HakuPath)
+}
+
+class IndexingSpec extends KoutaIntegrationSpec
+  with HakuFixtureWithIndexing with Validations with KonfoIndexingQueues with EventuallyMessages {
+
+  "Create haku" should "send indexing message after creating haku" in {
+    val oid = put(haku)
+    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
+  }
+
+  "Update haku" should "send indexing message after updating haku" in {
+    val oid = put(haku)
+    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
+
+    update(haku(oid, Arkistoitu), lastModified = get(oid, haku(oid)))
+
+    eventuallyIndexingMessages { _ should contain (s"""{"haut":["$oid"]}""") }
+  }
+}

--- a/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/IndexingSpec.scala
@@ -1,12 +1,12 @@
 package fi.oph.kouta.integration
 
 import fi.oph.kouta.domain.Arkistoitu
-import fi.oph.kouta.integration.fixture.EverythingFixtureWithIndexing
+import fi.oph.kouta.integration.fixture.IndexingFixture
 import fi.oph.kouta.validation.Validations
 import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 
 class IndexingSpec extends KoutaIntegrationSpec
-  with EverythingFixtureWithIndexing with Validations with KonfoIndexingQueues with EventuallyMessages {
+  with IndexingFixture with Validations with KonfoIndexingQueues with EventuallyMessages {
 
   "Create haku" should "send indexing message after creating haku" in {
     val oid = put(haku)
@@ -53,5 +53,19 @@ class IndexingSpec extends KoutaIntegrationSpec
 
     update(toteutus(oid, koulutusOid, Arkistoitu), lastModified = get(oid, toteutus(oid, koulutusOid)))
     eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
+  }
+
+  "Create valintaperuste" should "send indexing message after creating valintaperuste" in {
+    val oid = put(valintaperuste)
+    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$oid"]}""") }
+  }
+
+  "Update valintaperuste"  should "send indexing message after updating valintaperuste" in {
+    val id = put(valintaperuste)
+    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$id"]}""") }
+
+    update(valintaperuste(id, Arkistoitu), lastModified = get(id, valintaperuste(id)))
+
+    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$id"]}""") }
   }
 }

--- a/src/test/scala/fi/oph/kouta/integration/KeywordSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/KeywordSpec.scala
@@ -1,13 +1,12 @@
 package fi.oph.kouta.integration
 
-import fi.oph.kouta.KonfoIndexingQueues
 import fi.oph.kouta.domain.keyword.Keyword
-import fi.oph.kouta.domain.{AmmatillinenToteutusMetadata, Fi, ToteutusMetadata}
+import fi.oph.kouta.domain.{AmmatillinenToteutusMetadata, Fi}
 import fi.oph.kouta.integration.fixture.{KeywordFixture, KoulutusFixture, ToteutusFixture}
 import org.scalatest.BeforeAndAfterEach
 
 class KeywordSpec extends KoutaIntegrationSpec with KeywordFixture
-  with KoulutusFixture with ToteutusFixture with KonfoIndexingQueues with BeforeAndAfterEach {
+  with KoulutusFixture with ToteutusFixture with BeforeAndAfterEach {
 
   var koulutusOid = ""
 

--- a/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -9,7 +9,7 @@ import fi.oph.kouta.validation.Validations
 import org.json4s.jackson.Serialization.read
 
 class KoulutusSpec extends KoutaIntegrationSpec
-  with KoulutusFixture with ToteutusFixture with Validations with KonfoIndexingQueues with EventuallyMessages {
+  with KoulutusFixture with ToteutusFixture with Validations {
 
   it should "return 404 if koulutus not found" in {
     get("/koulutus/123") {
@@ -133,17 +133,4 @@ class KoulutusSpec extends KoutaIntegrationSpec
     }
   }
 
-  it should "send indexing message after creating koulutus" in {
-    val oid = put(koulutus)
-    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
-  }
-
-  it should "send indexing message after updating koulutus" in {
-    val oid = put(koulutus)
-    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
-
-    update(koulutus(oid, Arkistoitu), lastModified = get(oid, koulutus(oid)))
-
-    eventuallyIndexingMessages { _ should contain (s"""{"koulutukset":["$oid"]}""") }
-  }
 }

--- a/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -1,15 +1,13 @@
 package fi.oph.kouta.integration
 
 import fi.oph.kouta.TestData
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.fixture.{KoulutusFixture, ToteutusFixture}
 import fi.oph.kouta.validation.Validations
 import org.json4s.jackson.Serialization.read
 
-class KoulutusSpec extends KoutaIntegrationSpec
-  with KoulutusFixture with ToteutusFixture with Validations {
+class KoulutusSpec extends KoutaIntegrationSpec with KoulutusFixture with ToteutusFixture with Validations {
 
   it should "return 404 if koulutus not found" in {
     get("/koulutus/123") {

--- a/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
@@ -1,10 +1,10 @@
 package fi.oph.kouta.integration
 
 import fi.oph.kouta.domain._
-import fi.oph.kouta.{KonfoIndexingQueues, OrganisaatioServiceMock, TestData}
+import fi.oph.kouta.{OrganisaatioServiceMock, TestData}
 import org.json4s.jackson.Serialization.read
 
-class ListSpec extends KoutaIntegrationSpec with EverythingFixture with OrganisaatioServiceMock with KonfoIndexingQueues {
+class ListSpec extends KoutaIntegrationSpec with EverythingFixture with OrganisaatioServiceMock {
 
   val LonelyOid = "1.2.246.562.10.99999999999"
   val UnknownOid = "1.2.246.562.10.99999999998"

--- a/src/test/scala/fi/oph/kouta/integration/ModificationSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ModificationSpec.scala
@@ -1,12 +1,11 @@
 package fi.oph.kouta.integration
 
 import java.net.URLEncoder
+import java.time.Instant.now
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneId, ZonedDateTime}
-import java.time.Instant.now
 import java.util.UUID
 
-import fi.oph.kouta.KonfoIndexingQueues
 import fi.oph.kouta.TestData.inFuture
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
@@ -14,7 +13,7 @@ import fi.oph.kouta.servlet.AnythingServlet
 import org.json4s.jackson.Serialization.read
 
 
-class ModificationSpec extends KoutaIntegrationSpec with KonfoIndexingQueues with EverythingFixture {
+class ModificationSpec extends KoutaIntegrationSpec with EverythingFixture {
 
   val AnythingPath = "/anything"
   addServlet(new AnythingServlet(), AnythingPath)

--- a/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -121,18 +121,4 @@ class ToteutusSpec extends KoutaIntegrationSpec
       body should equal (validateErrorBody(invalidOidsMsg(List("katkarapu").map(OrganisaatioOid))))
     }
   }
-
-  it should "send indexing message after creating toteutus" in {
-    val oid = put(toteutus(koulutusOid))
-    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
-  }
-
-  it should "send indexing message after updating toteutus" in {
-    val oid = put(toteutus(koulutusOid))
-    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
-
-    update(toteutus(oid, koulutusOid, Arkistoitu), lastModified = get(oid, toteutus(oid, koulutusOid)))
-
-    eventuallyIndexingMessages { _ should contain (s"""{"toteutukset":["$oid"]}""") }
-  }
 }

--- a/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -1,14 +1,13 @@
 package fi.oph.kouta.integration
 
 import fi.oph.kouta.TestData
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.fixture.{KeywordFixture, KoulutusFixture, ToteutusFixture}
 import fi.oph.kouta.validation.Validations
 
 class ToteutusSpec extends KoutaIntegrationSpec
-  with KoulutusFixture with ToteutusFixture with KeywordFixture with Validations with KonfoIndexingQueues with EventuallyMessages {
+  with KoulutusFixture with ToteutusFixture with KeywordFixture with Validations {
 
   var koulutusOid = ""
 

--- a/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import fi.oph.kouta.TestData
 import fi.oph.kouta.TestData.MinYoValintaperuste
-import fi.oph.kouta.{EventuallyMessages, KonfoIndexingQueues}
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid.OrganisaatioOid
 import fi.oph.kouta.integration.fixture.ValintaperusteFixture

--- a/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
@@ -10,8 +10,7 @@ import fi.oph.kouta.domain.oid.OrganisaatioOid
 import fi.oph.kouta.integration.fixture.ValintaperusteFixture
 import fi.oph.kouta.validation.Validations
 
-class ValintaperusteSpec extends KoutaIntegrationSpec
-  with ValintaperusteFixture with Validations with KonfoIndexingQueues with EventuallyMessages {
+class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture with Validations {
 
   it should "return 404 if valintaperuste not found" in {
     get(s"/valintaperuste/${UUID.randomUUID()}") {
@@ -90,19 +89,5 @@ class ValintaperusteSpec extends KoutaIntegrationSpec
       }
       body should equal (validateErrorBody(validationMsg("saippua")))
     }
-  }
-
-  it should "send indexing message after creating valintaperuste" in {
-    val oid = put(valintaperuste)
-    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$oid"]}""") }
-  }
-
-  it should "send indexing message after updating valintaperuste" in {
-    val id = put(valintaperuste)
-    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$id"]}""") }
-
-    update(valintaperuste(id, Arkistoitu), lastModified = get(id, valintaperuste(id)))
-
-    eventuallyIndexingMessages { _ should contain (s"""{"valintaperusteet":["$id"]}""") }
   }
 }

--- a/src/test/scala/fi/oph/kouta/integration/fixture/HakuFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/HakuFixture.scala
@@ -1,18 +1,23 @@
 package fi.oph.kouta.integration.fixture
 
+import fi.oph.kouta.SqsInTransactionServiceIgnoringIndexing
 import fi.oph.kouta.TestData.JulkaistuHaku
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.service.HakuService
 import fi.oph.kouta.servlet.HakuServlet
-import org.scalactic.Equality
+
+object HakuServiceIgnoringIndexing extends HakuService(SqsInTransactionServiceIgnoringIndexing)
 
 trait HakuFixture { this: KoutaIntegrationSpec =>
 
   val HakuPath = "/haku"
 
-  addServlet(new HakuServlet(), HakuPath)
-  
+  def init(): Unit = addServlet(new HakuServlet(HakuServiceIgnoringIndexing), HakuPath)
+
+  init()
+
   val haku = JulkaistuHaku
 
   def haku(oid:String): Haku = haku.copy(oid = Some(HakuOid(oid)))

--- a/src/test/scala/fi/oph/kouta/integration/fixture/HakuFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/HakuFixture.scala
@@ -14,9 +14,9 @@ trait HakuFixture { this: KoutaIntegrationSpec =>
 
   val HakuPath = "/haku"
 
-  def init(): Unit = addServlet(new HakuServlet(HakuServiceIgnoringIndexing), HakuPath)
+  protected lazy val hakuService: HakuService = HakuServiceIgnoringIndexing
 
-  init()
+  addServlet(new HakuServlet(hakuService), HakuPath)
 
   val haku = JulkaistuHaku
 

--- a/src/test/scala/fi/oph/kouta/integration/fixture/HakukohdeFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/HakukohdeFixture.scala
@@ -2,20 +2,35 @@ package fi.oph.kouta.integration.fixture
 
 import java.util.UUID
 
+import fi.oph.kouta.SqsInTransactionServiceIgnoringIndexing
 import fi.oph.kouta.TestData.JulkaistuHakukohde
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.repository.SQLHelpers
+import fi.oph.kouta.service.HakukohdeService
 import fi.oph.kouta.servlet.HakukohdeServlet
-import org.scalactic.Equality
 
-trait HakukohdeFixture { this: KoutaIntegrationSpec =>
+object HakukohdeServiceWithoutIndexing extends HakukohdeService(SqsInTransactionServiceIgnoringIndexing)
+
+trait HakukohdeFixture extends SQLHelpers { this: KoutaIntegrationSpec =>
 
   val HakukohdePath = "/hakukohde"
 
-  addServlet(new HakukohdeServlet(), HakukohdePath)
+  protected lazy val hakukohdeService: HakukohdeService = HakukohdeServiceWithoutIndexing
+
+  addServlet(new HakukohdeServlet(hakukohdeService), HakukohdePath)
 
   val hakukohde = JulkaistuHakukohde
+
+  def getIds(hakukohde:Hakukohde): Hakukohde = {
+    import slick.jdbc.PostgresProfile.api._
+    hakukohde.copy(
+      liitteet = hakukohde.liitteet.map(l => l.copy(id = db.runBlocking(
+        sql"""select id from hakukohteiden_liitteet where hakukohde_oid = ${hakukohde.oid} and tyyppi = ${l.tyyppi}""".as[String]).headOption.map(UUID.fromString))),
+      valintakokeet = hakukohde.valintakokeet.map(l => l.copy(id = db.runBlocking(
+        sql"""select id from hakukohteiden_valintakokeet where hakukohde_oid = ${hakukohde.oid} and tyyppi = ${l.tyyppi}""".as[String]).headOption.map(UUID.fromString))),
+    )}
 
   def hakukohde(toteutusOid:String, hakuOid:String, valintaperusteId:UUID):Hakukohde = hakukohde.copy(
     toteutusOid = ToteutusOid(toteutusOid), hakuOid = HakuOid(hakuOid), valintaperusteId = Some(valintaperusteId))

--- a/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
@@ -1,18 +1,21 @@
 package fi.oph.kouta.integration.fixture
 
-import fi.oph.kouta.TestData
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.service.KoulutusService
 import fi.oph.kouta.servlet.KoulutusServlet
-import org.json4s.jackson.Serialization.read
-import org.scalactic.Equality
+import fi.oph.kouta.{SqsInTransactionServiceIgnoringIndexing, TestData}
+
+object KoulutusServiceIgnoringIndexing extends KoulutusService(SqsInTransactionServiceIgnoringIndexing)
 
 trait KoulutusFixture { this: KoutaIntegrationSpec =>
 
   val KoulutusPath = "/koulutus"
 
-  addServlet(new KoulutusServlet(), KoulutusPath)
+  protected lazy val koulutusService: KoulutusService = KoulutusServiceIgnoringIndexing
+
+  addServlet(new KoulutusServlet(koulutusService), KoulutusPath)
 
   val koulutus = TestData.AmmKoulutus
 

--- a/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
@@ -1,17 +1,22 @@
 package fi.oph.kouta.integration.fixture
 
+import fi.oph.kouta.SqsInTransactionServiceIgnoringIndexing
 import fi.oph.kouta.TestData._
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.service.ToteutusService
 import fi.oph.kouta.servlet.ToteutusServlet
-import org.scalactic.Equality
+
+object ToteutusServiceIgnoringIndexing extends ToteutusService(SqsInTransactionServiceIgnoringIndexing)
 
 trait ToteutusFixture { this: KoutaIntegrationSpec =>
 
   val ToteutusPath = "/toteutus"
 
-  addServlet(new ToteutusServlet(), ToteutusPath)
+  protected lazy val toteutusService: ToteutusService = ToteutusServiceIgnoringIndexing
+
+  addServlet(new ToteutusServlet(toteutusService), ToteutusPath)
 
   val opetus = ToteutuksenOpetus
   val ammMetatieto = AmmToteutuksenMetatieto

--- a/src/test/scala/fi/oph/kouta/integration/fixture/ValintaperusteFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/ValintaperusteFixture.scala
@@ -2,17 +2,22 @@ package fi.oph.kouta.integration.fixture
 
 import java.util.UUID
 
-import fi.oph.kouta.TestData
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid.OrganisaatioOid
 import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.service.ValintaperusteService
 import fi.oph.kouta.servlet.ValintaperusteServlet
+import fi.oph.kouta.{SqsInTransactionServiceIgnoringIndexing, TestData}
+
+object ValintaperusteServiceIgnoringIndexing extends ValintaperusteService(SqsInTransactionServiceIgnoringIndexing)
 
 trait ValintaperusteFixture { this: KoutaIntegrationSpec =>
 
   val ValintaperustePath = "/valintaperuste"
 
-  addServlet(new ValintaperusteServlet(), ValintaperustePath)
+  protected lazy val valintaperusteService: ValintaperusteService = ValintaperusteServiceIgnoringIndexing
+
+  addServlet(new ValintaperusteServlet(valintaperusteService), ValintaperustePath)
 
   val valintaperuste = TestData.AmmValintaperuste
 

--- a/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
@@ -4,7 +4,7 @@ import fi.oph.kouta.integration.KoutaIntegrationSpec
 import fi.oph.kouta.service._
 
 trait IndexingFixture extends KoulutusFixtureWithIndexing with HakuFixtureWithIndexing with ToteutusFixtureWithIndexing
-  with ValintaperusteFixtureWithIndexing {
+  with ValintaperusteFixtureWithIndexing with HakukohdeFixtureWithIndexing {
   this: KoutaIntegrationSpec =>
 }
 
@@ -26,4 +26,9 @@ trait ToteutusFixtureWithIndexing extends ToteutusFixture {
 trait ValintaperusteFixtureWithIndexing extends ValintaperusteFixture {
   this: KoutaIntegrationSpec =>
   override protected lazy val valintaperusteService = ValintaperusteService
+}
+
+trait HakukohdeFixtureWithIndexing extends HakukohdeFixture {
+  this: KoutaIntegrationSpec =>
+  override protected lazy val hakukohdeService = HakukohdeService
 }

--- a/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
@@ -1,0 +1,23 @@
+package fi.oph.kouta.integration.fixture
+
+import fi.oph.kouta.integration.KoutaIntegrationSpec
+import fi.oph.kouta.service._
+
+trait HakuFixtureWithIndexing extends HakuFixture {
+  this: KoutaIntegrationSpec =>
+  override protected lazy val hakuService = HakuService
+}
+
+trait KoulutusFixtureWithIndexing extends KoulutusFixture {
+  this: KoutaIntegrationSpec =>
+  override protected lazy val koulutusService = KoulutusService
+}
+
+trait ToteutusFixtureWithIndexing extends ToteutusFixture {
+  this: KoutaIntegrationSpec =>
+  override protected lazy val toteutusService = ToteutusService
+}
+
+trait EverythingFixtureWithIndexing extends KoulutusFixtureWithIndexing with HakuFixtureWithIndexing with ToteutusFixtureWithIndexing {
+  this: KoutaIntegrationSpec =>
+}

--- a/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
+++ b/src/test/scala/fi/oph/kouta/integration/fixture/indexingFixture.scala
@@ -3,6 +3,11 @@ package fi.oph.kouta.integration.fixture
 import fi.oph.kouta.integration.KoutaIntegrationSpec
 import fi.oph.kouta.service._
 
+trait IndexingFixture extends KoulutusFixtureWithIndexing with HakuFixtureWithIndexing with ToteutusFixtureWithIndexing
+  with ValintaperusteFixtureWithIndexing {
+  this: KoutaIntegrationSpec =>
+}
+
 trait HakuFixtureWithIndexing extends HakuFixture {
   this: KoutaIntegrationSpec =>
   override protected lazy val hakuService = HakuService
@@ -18,6 +23,7 @@ trait ToteutusFixtureWithIndexing extends ToteutusFixture {
   override protected lazy val toteutusService = ToteutusService
 }
 
-trait EverythingFixtureWithIndexing extends KoulutusFixtureWithIndexing with HakuFixtureWithIndexing with ToteutusFixtureWithIndexing {
+trait ValintaperusteFixtureWithIndexing extends ValintaperusteFixture {
   this: KoutaIntegrationSpec =>
+  override protected lazy val valintaperusteService = ValintaperusteService
 }


### PR DESCRIPTION
Siirsin kaikki indeksointi-jonoa testaavat testit yhteen testiluokkaan. Ne ajetaan edelleen localstackia vastaan, koska `IndexingSpec` käyttää `IndexingFixture` traittia, jossa määritellään käytettäväksi oletus-servicet, jotka luonnollisesti sisältävät täyden jononhallinnan.

Muissa testeissä käytetään tavallisia `Fixture`-traitteja, jotka käyttävät `Service`-objekteja, jotka ohittavat koko jonon.

Tällä tavalla jonotestit ajetaan edelleen localstackia vasten, niin nähdään että käytämme SQS:ää oikein. Toisaalta minkä tahansa muun testsuiten voi ajaa rivakasti ilman, että tarvitsee odotella localstackin käynnistymistä.