### PR TITLE
KTO-171 Poistettu tietokantatransaktio session hausta

### DIFF
--- a/src/main/scala/fi/oph/kouta/repository/koutaDatabase.scala
+++ b/src/main/scala/fi/oph/kouta/repository/koutaDatabase.scala
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
 import org.flywaydb.core.Flyway
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.TransactionIsolation
 import slick.jdbc.TransactionIsolation.Serializable
 
 import scala.concurrent.Await
@@ -34,8 +35,8 @@ object KoutaDatabase extends Logging {
     )
   }
 
-  def runBlockingTransactionally[R](operations: DBIO[R], timeout: Duration = Duration(20, TimeUnit.SECONDS)): Try[R] = {
-    Try(runBlocking(operations.transactionally.withTransactionIsolation(Serializable), timeout))
+  def runBlockingTransactionally[R](operations: DBIO[R], timeout: Duration = Duration(20, TimeUnit.SECONDS), isolation: TransactionIsolation = Serializable): Try[R] = {
+    Try(runBlocking(operations.transactionally.withTransactionIsolation(isolation), timeout))
   }
 
   def destroy() = {

--- a/src/main/scala/fi/oph/kouta/repository/sessionDAO.scala
+++ b/src/main/scala/fi/oph/kouta/repository/sessionDAO.scala
@@ -40,7 +40,7 @@ object SessionDAO extends SessionDAO with SessionSQL {
     runBlockingTransactionally(deleteSession(ticket), timeout = Duration(10, TimeUnit.SECONDS)).get
 
   override def get(id: UUID): Option[Session] = {
-    runBlockingTransactionally(getSession(id), timeout = Duration(2, TimeUnit.SECONDS)).get.map {
+    runBlocking(getSession(id), timeout = Duration(2, TimeUnit.SECONDS)).map {
       case (casTicket, personOid) =>
         val authorities = runBlocking(searchAuthoritiesBySession(id), Duration(2, TimeUnit.SECONDS))
         CasSession(ServiceTicket(casTicket.get), personOid, authorities.map(Authority(_)).toSet)


### PR DESCRIPTION
Transaktio aiheutti ongelmia, kun sessio oli joko 30 minuuttia tai tunnin vanha ja backendille lähetettiin monta rinnakkaista pyyntöä. Jos sessio oli tunnin vanha, sitä yritettiin poistaa monen käsittelijän toimesta, mikä aiheutti transaktio-ongelma. Samantapainen ongelma tuli kun sessio oli 30-60 minuuttia vanha, jolloin monta käsittelijää yrittivät päivittää voimassaoloaikaa samaan aikaan.

Transaktion poistaminen ei parhaan näkemykseni mukaan voi aiheuttaa tässä mitään pahaa. Jos sessio on jo kokonaan vanhentunut, kaikki sitä käyttävät kutsut yrittävät poistaa sessiota, tai osa näkee, että se on jo poistettu. Jos sessio on puolen tunnin ikäinen, jokainen päivittää vuorollaan last_read -arvoa, mutta kaikki käyttävät kuitenkin päivityshetken kellonaikaa, joten lopputulos on kuitenkin sama.