### PR TITLE
KTO-560

### DIFF
--- a/src/main/scala/fi/oph/kouta/service/koulutusService.scala
+++ b/src/main/scala/fi/oph/kouta/service/koulutusService.scala
@@ -96,10 +96,8 @@ class KoulutusService(sqsInTransactionService: SqsInTransactionService, val s3Im
 
   def listToteutukset(oid: KoulutusOid, organisaatioOid: OrganisaatioOid)(implicit authenticated: Authenticated): Seq[ToteutusListItem] =
     withAuthorizedOrganizationOids(organisaatioOid, AuthorizationRules(Role.Toteutus.readRoles, allowAccessToParentOrganizations = true)) {
-      _ match {
-        case Seq(OrganisaatioClient.OphOid) => ToteutusDAO.listByKoulutusOid(oid)
-        case x =>  ToteutusDAO.listByKoulutusOidAndAllowedOrganisaatiot(oid, x)
-      }
+      case Seq(OrganisaatioClient.OphOid) => ToteutusDAO.listByKoulutusOid(oid)
+      case x => ToteutusDAO.listByKoulutusOidAndAllowedOrganisaatiot(oid, x)
     }
 
   def search(organisaatioOid: OrganisaatioOid, params: Map[String, String])(implicit authenticated: Authenticated): KoulutusSearchResult = {

--- a/src/main/scala/fi/oph/kouta/service/koulutusService.scala
+++ b/src/main/scala/fi/oph/kouta/service/koulutusService.scala
@@ -96,7 +96,10 @@ class KoulutusService(sqsInTransactionService: SqsInTransactionService, val s3Im
 
   def listToteutukset(oid: KoulutusOid, organisaatioOid: OrganisaatioOid)(implicit authenticated: Authenticated): Seq[ToteutusListItem] =
     withAuthorizedOrganizationOids(organisaatioOid, AuthorizationRules(Role.Toteutus.readRoles, allowAccessToParentOrganizations = true)) {
-      ToteutusDAO.listByKoulutusOidAndAllowedOrganisaatiot(oid, _)
+      _ match {
+        case Seq(OrganisaatioClient.OphOid) => ToteutusDAO.listByKoulutusOid(oid)
+        case x =>  ToteutusDAO.listByKoulutusOidAndAllowedOrganisaatiot(oid, x)
+      }
     }
 
   def search(organisaatioOid: OrganisaatioOid, params: Map[String, String])(implicit authenticated: Authenticated): KoulutusSearchResult = {


### PR DESCRIPTION
Korjattu oikeuksia koulutuksen toteutukset -listaan niin, että oph:n käyttäjät näkevät kaikki koulutuksen toteutukset ja niiden lukumäärän