### PR TITLE
KTO-474

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Utility properties -->
-        <scala-utils.version>0.0.1-SNAPSHOT</scala-utils.version>
+        <scala-utils.version>1.2.1-SNAPSHOT</scala-utils.version>
+        <scala-logging.version>1.3.0-SNAPSHOT</scala-logging.version>
         <auditlogger.version>8.3.1-SNAPSHOT</auditlogger.version>
         <json4s.version>3.6.7</json4s.version>
         <logback-access.version>1.2.3</logback-access.version>
@@ -72,7 +73,7 @@
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-logging_2.12</artifactId>
-            <version>${scala-utils.version}</version>
+            <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade</groupId>
@@ -91,12 +92,16 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.github.cb372</groupId>
+                    <artifactId>scalacache-guava_2.12</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade</groupId>
             <artifactId>scala-properties_2.12</artifactId>
-            <version>${scala-utils.version}</version>
+            <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
@@ -137,6 +142,38 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.github.cb372</groupId>
+            <artifactId>scalacache-core_2.12</artifactId>
+            <version>0.28.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cb372</groupId>
+            <artifactId>scalacache-caffeine_2.12</artifactId>
+            <version>0.28.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cb372</groupId>
+            <artifactId>scalacache-guava_2.12</artifactId>
+            <version>0.28.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
 
         <!-- Audit logger -->
         <dependency>

--- a/src/main/resources/oph-configuration/kouta-backend.properties.template
+++ b/src/main/resources/oph-configuration/kouta-backend.properties.template
@@ -31,7 +31,7 @@ kouta-index.haku.filtered-list=https://{{host_virkailija}}/kouta-index/haku/filt
 kouta-index.hakukohde.filtered-list=https://{{host_virkailija}}/kouta-index/hakukohde/filtered-list
 kouta-index.valintaperuste.filtered-list=https://{{host_virkailija}}/kouta-index/valintaperuste/filtered-list
 kayttooikeus-service.userDetails.byUsername=http://{{host_alb_virkailija}}/kayttooikeus-service/userDetails/$1
-organisaatio-service.organisaatio.hierarkia=https://{{host_virkailija}}/organisaatio-service/rest/organisaatio/v4/hierarkia/hae
+organisaatio-service.organisaatio.oid.jalkelaiset=https://{{host_virkailija}}/organisaatio-service/rest/organisaatio/v4/$1/jalkelaiset
 
 ohjausparametrit-service.service=https://{{host_virkailija}}/ohjausparametrit-service
 ohjausparametrit-service.parametri=https://{{host_virkailija}}/ohjausparametrit-service/api/v1/rest/parametri/$1

--- a/src/main/scala/fi/oph/kouta/client/HttpClient.scala
+++ b/src/main/scala/fi/oph/kouta/client/HttpClient.scala
@@ -23,7 +23,7 @@ trait HttpClient extends KoutaJsonFormats {
   private val HeaderAcceptJson          = ("Accept", "application/json")
 
   def get[T](url: String, errorHandler: (String, Int, String) => Nothing = defaultErrorHandler, followRedirects: Boolean = false)(parse: String => T): T =
-    DefaultHttpClient.httpGet(url, defaultOptions(followRedirects):_*)
+    DefaultHttpClient.httpGet(url, defaultOptions(followRedirects):_*)(HeaderCallerId._2)
       .header(HeaderClientSubSystemCode._1, HeaderClientSubSystemCode._2)
       .header(HeaderCallerId._1, HeaderCallerId._2)
       .responseWithHeaders match {
@@ -32,7 +32,7 @@ trait HttpClient extends KoutaJsonFormats {
     }
 
   def post[B <: AnyRef, T](url: String, body: B, errorHandler: (String, Int, String) => Nothing = defaultErrorHandler, followRedirects: Boolean = false)(parse: String => T): T =
-    DefaultHttpClient.httpPost(url, Some(write[B](body)), defaultOptions(followRedirects):_*)
+    DefaultHttpClient.httpPost(url, Some(write[B](body)), defaultOptions(followRedirects):_*)(HeaderCallerId._2)
       .header(HeaderClientSubSystemCode._1, HeaderClientSubSystemCode._2)
       .header(HeaderCallerId._1, HeaderCallerId._2)
       .header(HeaderContentTypeJson._1, HeaderContentTypeJson._2)

--- a/src/main/scala/fi/oph/kouta/client/HttpClient.scala
+++ b/src/main/scala/fi/oph/kouta/client/HttpClient.scala
@@ -25,7 +25,6 @@ trait HttpClient extends KoutaJsonFormats {
   def get[T](url: String, errorHandler: (String, Int, String) => Nothing = defaultErrorHandler, followRedirects: Boolean = false)(parse: String => T): T =
     DefaultHttpClient.httpGet(url, defaultOptions(followRedirects):_*)(HeaderCallerId._2)
       .header(HeaderClientSubSystemCode._1, HeaderClientSubSystemCode._2)
-      .header(HeaderCallerId._1, HeaderCallerId._2)
       .responseWithHeaders match {
       case (200, _, response) => parse(response)
       case (xxx, _, response) => errorHandler(url, xxx, response)
@@ -34,7 +33,6 @@ trait HttpClient extends KoutaJsonFormats {
   def post[B <: AnyRef, T](url: String, body: B, errorHandler: (String, Int, String) => Nothing = defaultErrorHandler, followRedirects: Boolean = false)(parse: String => T): T =
     DefaultHttpClient.httpPost(url, Some(write[B](body)), defaultOptions(followRedirects):_*)(HeaderCallerId._2)
       .header(HeaderClientSubSystemCode._1, HeaderClientSubSystemCode._2)
-      .header(HeaderCallerId._1, HeaderCallerId._2)
       .header(HeaderContentTypeJson._1, HeaderContentTypeJson._2)
       .header(HeaderAcceptJson._1, HeaderAcceptJson._2)
       .responseWithHeaders match {

--- a/src/main/scala/fi/oph/kouta/client/organisaatioClient.scala
+++ b/src/main/scala/fi/oph/kouta/client/organisaatioClient.scala
@@ -12,12 +12,10 @@ import scala.annotation.tailrec
 
 trait OrganisaatioClient {
   type OrganisaatioOidsAndOppilaitostyypitFlat = (Seq[OrganisaatioOid], Seq[Koulutustyyppi])
-}
-
-object OrganisaatioClient extends OrganisaatioClient with HttpClient with KoutaJsonFormats {
-  val urlProperties: OphProperties = KoutaConfigurationFactory.configuration.urlProperties
 
   val OphOid: OrganisaatioOid = KoutaConfigurationFactory.configuration.securityConfiguration.rootOrganisaatio
+
+  protected def getHierarkia[R](oid: OrganisaatioOid, result: List[OidAndChildren] => R, lakkautetut: Boolean = false): R
 
   def getAllChildOidsFlat(oid: OrganisaatioOid, lakkautetut: Boolean = false): Seq[OrganisaatioOid] = oid match {
     case OphOid => Seq(OphOid)
@@ -33,23 +31,6 @@ object OrganisaatioClient extends OrganisaatioClient with HttpClient with KoutaJ
     case OphOid => (Seq(OphOid), Koulutustyyppi.values)
     case _ => getHierarkia(oid, orgs => (parentsAndChildren(oid, orgs), oppilaitostyypit(oid, orgs)))
   }
-
-  case class OrganisaatioResponse(numHits: Int, organisaatiot: List[OidAndChildren])
-  case class OidAndChildren(oid: OrganisaatioOid, children: List[OidAndChildren], parentOidPath: String, oppilaitostyyppi: Option[String])
-
-  private def getHierarkia[R](oid: OrganisaatioOid, result: List[OidAndChildren] => R, lakkautetut: Boolean = false) = {
-    val url = urlProperties.url("organisaatio-service.organisaatio.hierarkia", queryParams(oid.toString, lakkautetut))
-    get(url, followRedirects = true) { response =>
-      result(parse(response).extract[OrganisaatioResponse].organisaatiot)
-    }
-  }
-
-  private def queryParams(oid: String, lakkautetut: Boolean = false) =
-    toQueryParams(
-      "oid" -> oid,
-      "aktiiviset" -> "true",
-      "suunnitellut" -> "true",
-      "lakkautetut" -> Option(lakkautetut).map(_.toString).getOrElse("false"))
 
   private def children(oid: OrganisaatioOid, organisaatiot: List[OidAndChildren]): Seq[OrganisaatioOid] =
     find(oid, organisaatiot).map(x => x.oid +: childOidsFlat(x)).getOrElse(Seq()).distinct
@@ -84,4 +65,85 @@ object OrganisaatioClient extends OrganisaatioClient with HttpClient with KoutaJ
       case None => None
       case Some(org) => org.oppilaitostyyppi
     }}
+}
+
+object CachedOrganisaatioHierarkiaClient extends HttpClient with KoutaJsonFormats {
+
+  import scala.concurrent.duration._
+  import scalacache.modes.sync._
+  import scalacache.caffeine._
+  import scalacache.memoization.memoizeSync
+
+  val urlProperties: OphProperties = KoutaConfigurationFactory.configuration.urlProperties
+
+  val OphOid: OrganisaatioOid = KoutaConfigurationFactory.configuration.securityConfiguration.rootOrganisaatio
+
+  implicit val WholeHierarkiaCache = CaffeineCache[OrganisaatioResponse]
+
+  def getWholeOrganisaatioHierarkiaCached(): OrganisaatioResponse = memoizeSync[OrganisaatioResponse](Some(45.minutes)) {
+    val url = urlProperties.url("organisaatio-service.organisaatio.oid.jalkelaiset", OphOid.s)
+    get(url, followRedirects = true) { response =>
+      parse(response).extract[OrganisaatioResponse]
+    }
+  }
+}
+
+object OrganisaatioClient extends OrganisaatioClient {
+
+  import scalacache._
+  import scala.concurrent.duration._
+  import scalacache.modes.sync._
+  import scalacache.caffeine._
+
+  //TODO: @tailrec
+  private def pickChildrenRecursively(current: OidAndChildren, oid: OrganisaatioOid): Option[OidAndChildren] = {
+    if(current.oid.equals(oid)) {
+      Some(current)
+    } else {
+      val children = current.children.map(pickChildrenRecursively(_, oid)).flatten
+      if(children.isEmpty) {
+        None
+      } else {
+        Some(current.copy(children = children))
+      }
+    }
+  }
+
+  private def findHierarkia(oid: OrganisaatioOid): List[OidAndChildren] =
+    CachedOrganisaatioHierarkiaClient.getWholeOrganisaatioHierarkiaCached()
+      .organisaatiot.map(pickChildrenRecursively(_, oid)).flatten
+
+  implicit val HierarkiaCache = CaffeineCache[List[OidAndChildren]]
+
+  private def cacheHierarkia(oid: OrganisaatioOid): Any =
+    sync.put(oid)(findHierarkia(oid), Some(45.minutes))
+
+  private def getCachedHierarkia(oid: OrganisaatioOid): Option[List[OidAndChildren]] =
+    sync.get(oid)
+
+  //TODO: @tailrec
+  private def removeLakkautetutRecursively(current: OidAndChildren): Option[OidAndChildren] = {
+    if(current.isPassiivinen) {
+      None
+    } else {
+      Some(current.copy(children = current.children.map(removeLakkautetutRecursively(_)).flatten))
+    }
+  }
+
+  protected def getHierarkia[R](oid: OrganisaatioOid, result: List[OidAndChildren] => R, lakkautetut: Boolean = false) = {
+    val hierarkia: List[OidAndChildren] = getCachedHierarkia(oid).orElse {
+      cacheHierarkia(oid)
+      getCachedHierarkia(oid)
+    }.getOrElse(List.empty[OidAndChildren])
+
+    result {
+      if(lakkautetut) { hierarkia } else { hierarkia.map(removeLakkautetutRecursively).flatten }
+    }
+  }
+}
+
+case class OrganisaatioResponse(numHits: Int, organisaatiot: List[OidAndChildren])
+
+case class OidAndChildren(oid: OrganisaatioOid, children: List[OidAndChildren], parentOidPath: String, oppilaitostyyppi: Option[String], status: String) {
+  def isPassiivinen = status.equalsIgnoreCase("PASSIIVINEN")
 }

--- a/src/main/scala/fi/oph/kouta/service/koulutusService.scala
+++ b/src/main/scala/fi/oph/kouta/service/koulutusService.scala
@@ -3,7 +3,7 @@ package fi.oph.kouta.service
 import java.time.Instant
 
 import fi.oph.kouta.auditlog.AuditLog
-import fi.oph.kouta.client.{KoutaIndexClient, OrganisaatioClient}
+import fi.oph.kouta.client.{KoutaIndexClient, OrganisaatioService}
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid.{KoulutusOid, OrganisaatioOid}
 import fi.oph.kouta.images.{S3ImageService, TeemakuvaService}
@@ -74,7 +74,7 @@ class KoulutusService(sqsInTransactionService: SqsInTransactionService, val s3Im
 
   def getTarjoajanJulkaistutKoulutukset(organisaatioOid: OrganisaatioOid)(implicit authenticated: Authenticated): Seq[Koulutus] =
     withRootAccess(indexerRoles) {
-      KoulutusDAO.getJulkaistutByTarjoajaOids(OrganisaatioClient.getAllChildOidsFlat(organisaatioOid, lakkautetut = true))
+      KoulutusDAO.getJulkaistutByTarjoajaOids(OrganisaatioService.getAllChildOidsFlat(organisaatioOid, lakkautetut = true))
     }
 
   def toteutukset(oid: KoulutusOid, vainJulkaistut: Boolean)(implicit authenticated: Authenticated): Seq[Toteutus] =
@@ -96,7 +96,7 @@ class KoulutusService(sqsInTransactionService: SqsInTransactionService, val s3Im
 
   def listToteutukset(oid: KoulutusOid, organisaatioOid: OrganisaatioOid)(implicit authenticated: Authenticated): Seq[ToteutusListItem] =
     withAuthorizedOrganizationOids(organisaatioOid, AuthorizationRules(Role.Toteutus.readRoles, allowAccessToParentOrganizations = true)) {
-      case Seq(OrganisaatioClient.OphOid) => ToteutusDAO.listByKoulutusOid(oid)
+      case Seq(OrganisaatioService.OphOid) => ToteutusDAO.listByKoulutusOid(oid)
       case x => ToteutusDAO.listByKoulutusOidAndAllowedOrganisaatiot(oid, x)
     }
 

--- a/src/main/scala/fi/oph/kouta/service/service.scala
+++ b/src/main/scala/fi/oph/kouta/service/service.scala
@@ -3,7 +3,6 @@ package fi.oph.kouta.service
 import java.time.Instant
 
 import fi.oph.kouta.client.OrganisaatioClient
-import fi.oph.kouta.client.OrganisaatioClient.OrganisaatioOidsAndOppilaitostyypitFlat
 import fi.oph.kouta.config.KoutaConfigurationFactory
 import fi.oph.kouta.domain.Julkaistu
 import fi.oph.kouta.domain.oid.{OrganisaatioOid, UserOid}
@@ -13,6 +12,7 @@ import fi.oph.kouta.validation.{IsValid, NoErrors, Validatable}
 import fi.vm.sade.utils.slf4j.Logging
 
 import scala.collection.IterableView
+import fi.oph.kouta.client.OrganisaatioClient.OrganisaatioOidsAndOppilaitostyypitFlat
 
 trait ValidatingService[E <: Validatable] {
 

--- a/src/main/scala/fi/oph/kouta/service/service.scala
+++ b/src/main/scala/fi/oph/kouta/service/service.scala
@@ -2,7 +2,7 @@ package fi.oph.kouta.service
 
 import java.time.Instant
 
-import fi.oph.kouta.client.OrganisaatioClient
+import fi.oph.kouta.client.OrganisaatioService
 import fi.oph.kouta.config.KoutaConfigurationFactory
 import fi.oph.kouta.domain.Julkaistu
 import fi.oph.kouta.domain.oid.{OrganisaatioOid, UserOid}
@@ -12,7 +12,7 @@ import fi.oph.kouta.validation.{IsValid, NoErrors, Validatable}
 import fi.vm.sade.utils.slf4j.Logging
 
 import scala.collection.IterableView
-import fi.oph.kouta.client.OrganisaatioClient.OrganisaatioOidsAndOppilaitostyypitFlat
+import fi.oph.kouta.client.OrganisaatioService.OrganisaatioOidsAndOppilaitostyypitFlat
 
 trait ValidatingService[E <: Validatable] {
 
@@ -168,9 +168,9 @@ trait AuthorizationService extends Logging {
 
       val requestedOrganizations =
         if( authorizationRules.allowAccessToParentOrganizations ) {
-          OrganisaatioClient.getAllChildAndParentOidsWithOppilaitostyypitFlat(oid)
+          OrganisaatioService.getAllChildAndParentOidsWithOppilaitostyypitFlat(oid)
         } else {
-          OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(oid)
+          OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(oid)
         }
 
       requestedOrganizations match {
@@ -185,10 +185,10 @@ trait AuthorizationService extends Logging {
     }
 
   protected def lazyFlatChildrenAndParents(orgs: Set[OrganisaatioOid]): OrganisaatioOidsAndOppilaitostyypitFlatView =
-    orgs.view.map(oid => OrganisaatioClient.getAllChildAndParentOidsWithOppilaitostyypitFlat(oid))
+    orgs.view.map(oid => OrganisaatioService.getAllChildAndParentOidsWithOppilaitostyypitFlat(oid))
 
   protected def lazyFlatChildren(orgs: Set[OrganisaatioOid]): OrganisaatioOidsAndOppilaitostyypitFlatView =
-    orgs.view.map(oid => OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(oid))
+    orgs.view.map(oid => OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(oid))
 
   def hasRootAccess(roles: Seq[Role])(implicit authenticated: Authenticated): Boolean =
     roles.exists(role => authenticated.session.roleMap.get(role).exists(_.contains(rootOrganisaatioOid)))

--- a/src/test/resources/data/organisaatio.json
+++ b/src/test/resources/data/organisaatio.json
@@ -1,5 +1,5 @@
 {
-    "numHits": 3,
+    "numHits": 31,
     "organisaatiot": [
         {
             "aliOrganisaatioMaara": 1,
@@ -100,6 +100,627 @@
             "status": "AKTIIVINEN",
             "toimipistekoodi": "",
             "ytunnus": "0993644-6"
+        },
+        {
+            "oid": "1.2.246.562.10.53191981389",
+            "alkuPvm": 757634400000,
+            "parentOid": "1.2.246.562.10.00000000001",
+            "parentOidPath": "1.2.246.562.10.53191981389/1.2.246.562.10.00000000001",
+            "ytunnus": "0952029-9",
+            "toimipistekoodi": "",
+            "match": false,
+            "nimi": {
+                "fi": "Puolustusvoimat"
+            },
+            "kieletUris": [
+                "oppilaitoksenopetuskieli_1#1"
+            ],
+            "kotipaikkaUri": "kunta_091",
+            "children": [
+                {
+                    "oid": "1.2.246.562.10.46312206843",
+                    "alkuPvm": 925246800000,
+                    "parentOid": "1.2.246.562.10.53191981389",
+                    "parentOidPath": "1.2.246.562.10.46312206843/1.2.246.562.10.53191981389/1.2.246.562.10.00000000001",
+                    "oppilaitosKoodi": "02358",
+                    "oppilaitostyyppi": "oppilaitostyyppi_43#1",
+                    "toimipistekoodi": "02358",
+                    "match": true,
+                    "nimi": {
+                        "fi": "Maanpuolustuskorkeakoulu"
+                    },
+                    "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                    ],
+                    "kotipaikkaUri": "kunta_091",
+                    "children": [],
+                    "aliOrganisaatioMaara": 0,
+                    "organisaatiotyypit": [
+                        "organisaatiotyyppi_02"
+                    ],
+                    "status": "AKTIIVINEN"
+                }
+            ],
+            "aliOrganisaatioMaara": 7,
+            "virastoTunnus": "0999999-9",
+            "organisaatiotyypit": [
+                "organisaatiotyyppi_01"
+            ],
+            "status": "AKTIIVINEN"
+        },
+        {
+            "oid": "1.2.246.562.10.53814745062",
+            "alkuPvm": 313106400000,
+            "parentOid": "1.2.246.562.10.00000000001",
+            "parentOidPath": "1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+            "ytunnus": "0313471-7",
+            "toimipistekoodi": "",
+            "match": true,
+            "nimi": {
+                "fi": "Helsingin Yliopisto"
+            },
+            "kieletUris": [
+                "oppilaitoksenopetuskieli_1#1"
+            ],
+            "kotipaikkaUri": "kunta_091",
+            "children": [
+                {
+                    "oid": "1.2.246.562.10.39218317368",
+                    "alkuPvm": 725839200000,
+                    "parentOid": "1.2.246.562.10.53814745062",
+                    "parentOidPath": "1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                    "oppilaitosKoodi": "01901",
+                    "oppilaitostyyppi": "oppilaitostyyppi_42#1",
+                    "toimipistekoodi": "01901",
+                    "match": false,
+                    "nimi": {
+                        "sv": "Helsingfors universitet",
+                        "fi": "Helsingin yliopisto",
+                        "en": "University of Helsinki"
+                    },
+                    "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1",
+                        "oppilaitoksenopetuskieli_2#1",
+                        "oppilaitoksenopetuskieli_4#1"
+                    ],
+                    "kotipaikkaUri": "kunta_091",
+                    "children": [
+                        {
+                            "oid": "1.2.246.562.10.74478323608",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.74478323608/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190115",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Teologiska fakulteten",
+                                "fi": "Helsingin yliopisto, Teologinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Theology"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.46789068684",
+                            "alkuPvm": 1546293600000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.46789068684/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190130",
+                            "match": false,
+                            "nimi": {
+                                "fi": "Helsingin yliopisto, Koulutus- ja kehittämispalvelut"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.94997228401",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.94997228401/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190117",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Medicinska fakulteten",
+                                "fi": "Helsingin yliopisto, Lääketieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Medicine"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [
+                                {
+                                    "oid": "1.2.246.562.10.27277224708",
+                                    "alkuPvm": 1553205600000,
+                                    "parentOid": "1.2.246.562.10.94997228401",
+                                    "parentOidPath": "1.2.246.562.10.27277224708/1.2.246.562.10.94997228401/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                                    "toimipistekoodi": "0190133",
+                                    "match": false,
+                                    "nimi": {
+                                        "sv": "Helsingfors universitet, Medicinska fakulteten, Yrkesinriktad påbyggnadsutbildning",
+                                        "fi": "Helsingin yliopisto, Lääketieteellinen tiedekunta, Ammatillinen jatkokoulutus",
+                                        "en": "University of Helsinki, Faculty of Medicine, Postgraduate professional education"
+                                    },
+                                    "kieletUris": [
+                                        "oppilaitoksenopetuskieli_1#1",
+                                        "oppilaitoksenopetuskieli_2#1",
+                                        "oppilaitoksenopetuskieli_4#1"
+                                    ],
+                                    "kotipaikkaUri": "kunta_091",
+                                    "children": [],
+                                    "aliOrganisaatioMaara": 0,
+                                    "organisaatiotyypit": [
+                                        "organisaatiotyyppi_03"
+                                    ],
+                                    "status": "AKTIIVINEN"
+                                }
+                            ],
+                            "aliOrganisaatioMaara": 1,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.74168867104",
+                            "alkuPvm": 1454536800000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.74168867104/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190113",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Öppna universitetet",
+                                "fi": "Helsingin yliopisto, Avoin yliopisto",
+                                "en": "University of Helsinki, Open University"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.79378653079",
+                            "alkuPvm": 1546293600000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.79378653079/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190129",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Språkcentrum",
+                                "fi": "Helsingin yliopisto, Kielikeskus",
+                                "en": "University of Helsinki, Language Centre"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.94639300915",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.94639300915/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190119",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Matematisk-naturvetenskapliga fakulteten",
+                                "fi": "Helsingin yliopisto, Matemaattis-luonnontieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Science"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.45501388404",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.45501388404/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190123",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Veterinärmedicinska fakulteten",
+                                "fi": "Helsingin yliopisto, Eläinlääketieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Veterinary Medicine"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.37753840224",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.37753840224/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190116",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Juridiska fakulteten",
+                                "fi": "Helsingin yliopisto, Oikeustieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Law"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.80593660139",
+                            "alkuPvm": 1055365200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.80593660139/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190126",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Farmaceutiska fakulteten",
+                                "fi": "Helsingin yliopisto, Farmasian tiedekunta",
+                                "en": "University of Helsinki, Faculty of Pharmacy"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.80520096209",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.80520096209/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190121",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Statsvetenskapliga fakulteten",
+                                "fi": "Helsingin yliopisto, Valtiotieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Social Sciences"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.41941575486",
+                            "alkuPvm": 1053982800000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.41941575486/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190124",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Bio- och miljövetenskapliga fakulteten",
+                                "fi": "Helsingin yliopisto, Bio- ja ympäristötieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Biological and Environmental Sciences"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.67451633415",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.67451633415/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190120",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Pedagogiska fakulteten",
+                                "fi": "Helsingin yliopisto, Kasvatustieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Educational Sciences"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.61397511793",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.61397511793/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190118",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Humanistiska fakulteten",
+                                "fi": "Helsingin yliopisto, Humanistinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Arts"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.27341716119",
+                            "alkuPvm": 1508274000000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.27341716119/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190128",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Doktorandprogram",
+                                "fi": "Helsingin yliopisto, Tohtoriohjelmat",
+                                "en": "University of Helsinki, Doctoral programmes"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.73307006806",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.73307006806/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190127",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Svenska social- och kommunalhögskolan vid Helsingfors universitet",
+                                "fi": "Svenska social- och kommunalhögskolan vid Helsingfors universitet",
+                                "en": "Swedish School of Social Science"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        },
+                        {
+                            "oid": "1.2.246.562.10.445049088710",
+                            "alkuPvm": 725839200000,
+                            "parentOid": "1.2.246.562.10.39218317368",
+                            "parentOidPath": "1.2.246.562.10.445049088710/1.2.246.562.10.39218317368/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0190122",
+                            "match": false,
+                            "nimi": {
+                                "sv": "Helsingfors universitet, Agrikultur-forstvetenskapliga fakulteten",
+                                "fi": "Helsingin yliopisto, Maatalous-metsätieteellinen tiedekunta",
+                                "en": "University of Helsinki, Faculty of Agriculture and Forestry"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1",
+                                "oppilaitoksenopetuskieli_2#1",
+                                "oppilaitoksenopetuskieli_4#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        }
+                    ],
+                    "aliOrganisaatioMaara": 16,
+                    "organisaatiotyypit": [
+                        "organisaatiotyyppi_02"
+                    ],
+                    "status": "AKTIIVINEN"
+                },
+                {
+                    "oid": "1.2.246.562.10.81927839589",
+                    "alkuPvm": 694216800000,
+                    "parentOid": "1.2.246.562.10.53814745062",
+                    "parentOidPath": "1.2.246.562.10.81927839589/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                    "oppilaitosKoodi": "00842",
+                    "oppilaitostyyppi": "oppilaitostyyppi_19#1",
+                    "toimipistekoodi": "00842",
+                    "match": false,
+                    "nimi": {
+                        "fi": "Helsingin yliopiston Viikin normaalikoulu"
+                    },
+                    "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                    ],
+                    "kotipaikkaUri": "kunta_091",
+                    "children": [
+                        {
+                            "oid": "1.2.246.562.10.80918582927",
+                            "alkuPvm": 694216800000,
+                            "parentOid": "1.2.246.562.10.81927839589",
+                            "parentOidPath": "1.2.246.562.10.80918582927/1.2.246.562.10.81927839589/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0084201",
+                            "match": false,
+                            "nimi": {
+                                "fi": "Helsingin yliopiston Viikin normaalikoulu"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        }
+                    ],
+                    "aliOrganisaatioMaara": 1,
+                    "organisaatiotyypit": [
+                        "organisaatiotyyppi_02"
+                    ],
+                    "status": "AKTIIVINEN"
+                },
+                {
+                    "oid": "1.2.246.562.10.112212847610",
+                    "alkuPvm": 694216800000,
+                    "parentOid": "1.2.246.562.10.53814745062",
+                    "parentOidPath": "1.2.246.562.10.112212847610/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                    "oppilaitosKoodi": "00083",
+                    "oppilaitostyyppi": "oppilaitostyyppi_19#1",
+                    "toimipistekoodi": "00083",
+                    "match": false,
+                    "nimi": {
+                        "fi": "Helsingin Normaalilyseo"
+                    },
+                    "kieletUris": [
+                        "oppilaitoksenopetuskieli_1#1"
+                    ],
+                    "kotipaikkaUri": "kunta_091",
+                    "children": [
+                        {
+                            "oid": "1.2.246.562.10.69971467043",
+                            "alkuPvm": 694216800000,
+                            "parentOid": "1.2.246.562.10.112212847610",
+                            "parentOidPath": "1.2.246.562.10.69971467043/1.2.246.562.10.112212847610/1.2.246.562.10.53814745062/1.2.246.562.10.00000000001",
+                            "toimipistekoodi": "0008301",
+                            "match": false,
+                            "nimi": {
+                                "fi": "Helsingin Normaalilyseo"
+                            },
+                            "kieletUris": [
+                                "oppilaitoksenopetuskieli_1#1"
+                            ],
+                            "kotipaikkaUri": "kunta_091",
+                            "children": [],
+                            "aliOrganisaatioMaara": 0,
+                            "organisaatiotyypit": [
+                                "organisaatiotyyppi_03"
+                            ],
+                            "status": "AKTIIVINEN"
+                        }
+                    ],
+                    "aliOrganisaatioMaara": 1,
+                    "organisaatiotyypit": [
+                        "organisaatiotyyppi_02"
+                    ],
+                    "status": "AKTIIVINEN"
+                }
+            ],
+            "aliOrganisaatioMaara": 3,
+            "organisaatiotyypit": [
+                "organisaatiotyyppi_01"
+            ],
+            "status": "AKTIIVINEN"
+        },
+        {
+            "oid": "1.2.246.562.10.99999999999",
+            "parentOidPath": "1.2.246.562.10.99999999999/1.2.246.562.10.00000000001",
+            "oppilaitostyyppi": "oppilaitostyyppi_21#1",
+            "children" : [],
+            "status": "AKTIIVINEN"
+        },
+        {
+            "oid": "1.2.246.562.10.463122068666",
+            "parentOidPath": "1.2.246.562.10.463122068666/1.2.246.562.10.00000000001",
+            "oppilaitostyyppi": "oppilaitostyyppi_21#1",
+            "children" : [],
+            "status": "AKTIIVINEN"
         }
     ]
 }

--- a/src/test/resources/kouta-backend.properties
+++ b/src/test/resources/kouta-backend.properties
@@ -1,6 +1,6 @@
 # TODO: https:// toimimaan mockserverin kanssa
 url-virkailija=http://${host.virkailija}
-organisaatio-service.organisaatio.hierarkia=${url-virkailija}/organisaatio-service/rest/organisaatio/v4/hierarkia/hae
+organisaatio-service.organisaatio.oid.jalkelaiset=${url-virkailija}/organisaatio-service/rest/organisaatio/v4/$1/jalkelaiset
 kayttooikeus-service.userDetails.byUsername=${url-virkailija}/kayttooikeus-service/userDetails/$1
 kouta-index.koulutus.filtered-list=${url-virkailija}/kouta-index/koulutus/filtered-list
 kouta-index.toteutus.filtered-list=${url-virkailija}/kouta-index/toteutus/filtered-list

--- a/src/test/scala/fi/oph/kouta/client/OrganisaatioClientSpec.scala
+++ b/src/test/scala/fi/oph/kouta/client/OrganisaatioClientSpec.scala
@@ -13,27 +13,27 @@ class OrganisaatioClientSpec extends KoutaClientSpec with OrganisaatioServiceMoc
   }
 
   "getAllChildOidsAndOppilaitostyypitFlat" should "return flat list of child organisations" in {
-    OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._1 should contain theSameElementsAs
+    OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._1 should contain theSameElementsAs
       List(ChildOid, GrandChildOid, EvilGrandChildOid)
   }
   it should "return the root organization oid when called with the root organization oid" in {
-    val response = OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OphOid)
+    val response = OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(OphOid)
     response._1 should contain theSameElementsAs List(OphOid)
     response._2 should contain theSameElementsAs Koulutustyyppi.values
   }
   it should "return empty list with unknown oid when requesting children" in {
-    OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.3"))._1 should contain theSameElementsAs List()
+    OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.3"))._1 should contain theSameElementsAs List()
   }
   it should "return a flat list of oppilaitostyyppi present in parents and children" in {
-    OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._2 should contain theSameElementsAs List(Amm)
+    OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._2 should contain theSameElementsAs List(Amm)
   }
   it should "return a flat list of oppilaitostyyppi present in parents and children 2" in {
-    OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(YoOid)._2 should contain theSameElementsAs List(Yo)
+    OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(YoOid)._2 should contain theSameElementsAs List(Yo)
   }
   it should "return correct oppilaitostyypit for koulutustoimija when requesting only children" in {
-    OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
+    OrganisaatioService.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
   }
   it should "return correct oppilaitostyypit for koulutustoimija when requesting both parents and children" in {
-    OrganisaatioClient.getAllChildAndParentOidsWithOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
+    OrganisaatioService.getAllChildAndParentOidsWithOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
   }
 }

--- a/src/test/scala/fi/oph/kouta/client/OrganisaatioClientSpec.scala
+++ b/src/test/scala/fi/oph/kouta/client/OrganisaatioClientSpec.scala
@@ -7,35 +7,33 @@ import fi.oph.kouta.mocks.OrganisaatioServiceMock
 
 class OrganisaatioClientSpec extends KoutaClientSpec with OrganisaatioServiceMock {
 
+  override def beforeAll() = {
+    super.beforeAll()
+    mockOrganisaatioResponse()
+  }
+
   "getAllChildOidsAndOppilaitostyypitFlat" should "return flat list of child organisations" in {
-    mockOrganisaatioResponse(ChildOid)
     OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._1 should contain theSameElementsAs
       List(ChildOid, GrandChildOid, EvilGrandChildOid)
   }
   it should "return the root organization oid when called with the root organization oid" in {
-    mockOrganisaatioResponse(OphOid, """{"numHits": 0,"organisaatiot": []}""")
     val response = OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OphOid)
     response._1 should contain theSameElementsAs List(OphOid)
     response._2 should contain theSameElementsAs Koulutustyyppi.values
   }
   it should "return empty list with unknown oid when requesting children" in {
-    mockOrganisaatioResponse(OrganisaatioOid("1.2.3"), NotFoundOrganisaatioResponse)
     OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.3"))._1 should contain theSameElementsAs List()
   }
   it should "return a flat list of oppilaitostyyppi present in parents and children" in {
-    mockOrganisaatioResponse(ChildOid)
     OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(ChildOid)._2 should contain theSameElementsAs List(Amm)
   }
   it should "return a flat list of oppilaitostyyppi present in parents and children 2" in {
-    mockOrganisaatioResponse(YoOid, responseFromResource("mpkk"))
     OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(YoOid)._2 should contain theSameElementsAs List(Yo)
   }
   it should "return correct oppilaitostyypit for koulutustoimija when requesting only children" in {
-    mockOrganisaatioResponse(OrganisaatioOid("1.2.246.562.10.53814745062"), responseFromResource("1.2.246.562.10.53814745062"))
     OrganisaatioClient.getAllChildOidsAndOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
   }
   it should "return correct oppilaitostyypit for koulutustoimija when requesting both parents and children" in {
-    mockOrganisaatioResponse(OrganisaatioOid("1.2.246.562.10.53814745062"), responseFromResource("1.2.246.562.10.53814745062"))
     OrganisaatioClient.getAllChildAndParentOidsWithOppilaitostyypitFlat(OrganisaatioOid("1.2.246.562.10.53814745062"))._2 should contain theSameElementsAs List(Yo, Lk)
   }
 }

--- a/src/test/scala/fi/oph/kouta/integration/IndexerSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/IndexerSpec.scala
@@ -54,7 +54,7 @@ class IndexerSpec extends KoutaIntegrationSpec with EverythingFixture with Index
 
   "List koulutukset by tarjoaja" should "list all koulutukset distinct" in {
     val oid = put(koulutus.copy(tarjoajat = List(ChildOid, GrandChildOid)))
-    mockOrganisaatioResponse(ChildOid, lakkautetut = true)
+    mockOrganisaatioResponse()
     get(s"$IndexerPath/tarjoaja/$ChildOid/koulutukset", headers = Seq(sessionHeader(indexerSession))) {
       status should equal (200)
       read[List[Koulutus]](body).filter(_.oid.get.s == oid).size should equal (1)

--- a/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
@@ -73,11 +73,6 @@ trait AccessControlSpec extends ScalatraFlatSpec with OrganisaatioServiceMock { 
     addTestSessions()
 
     mockOrganisaatioResponse()
-
-    /*mockOrganisaatioResponses(EvilChildOid, ChildOid, ParentOid, GrandChildOid)
-    mockSingleOrganisaatioResponses(LonelyOid)
-    mockOrganisaatioResponse(YoOid, responseFromResource("mpkk"))
-    mockOrganisaatioResponse(AmmOid, singleOidOrganisaatioResponse(AmmOid.s))*/
   }
 
   override def afterAll(): Unit = {
@@ -85,7 +80,6 @@ trait AccessControlSpec extends ScalatraFlatSpec with OrganisaatioServiceMock { 
     stopServiceMocking()
   }
 
-  //val testSessions: mutable.Map[Symbol, (String, String)] = mutable.Map.empty
   val crudSessions: mutable.Map[OrganisaatioOid, UUID] = mutable.Map.empty
   val readSessions: mutable.Map[OrganisaatioOid, UUID] = mutable.Map.empty
 

--- a/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
@@ -72,10 +72,12 @@ trait AccessControlSpec extends ScalatraFlatSpec with OrganisaatioServiceMock { 
     startServiceMocking()
     addTestSessions()
 
-    mockOrganisaatioResponses(EvilChildOid, ChildOid, ParentOid, GrandChildOid)
+    mockOrganisaatioResponse()
+
+    /*mockOrganisaatioResponses(EvilChildOid, ChildOid, ParentOid, GrandChildOid)
     mockSingleOrganisaatioResponses(LonelyOid)
     mockOrganisaatioResponse(YoOid, responseFromResource("mpkk"))
-    mockOrganisaatioResponse(AmmOid, singleOidOrganisaatioResponse(AmmOid.s))
+    mockOrganisaatioResponse(AmmOid, singleOidOrganisaatioResponse(AmmOid.s))*/
   }
 
   override def afterAll(): Unit = {

--- a/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
@@ -25,10 +25,7 @@ class ListSpec extends KoutaIntegrationSpec with AccessControlSpec with Everythi
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
     mockOrganisaatioResponse()
-    //mockOrganisaatioResponse(UnknownOid, NotFoundOrganisaatioResponse)
-
     createTestData()
   }
 

--- a/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
+++ b/src/test/scala/fi/oph/kouta/integration/ListSpec.scala
@@ -26,7 +26,8 @@ class ListSpec extends KoutaIntegrationSpec with AccessControlSpec with Everythi
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    mockOrganisaatioResponse(UnknownOid, NotFoundOrganisaatioResponse)
+    mockOrganisaatioResponse()
+    //mockOrganisaatioResponse(UnknownOid, NotFoundOrganisaatioResponse)
 
     createTestData()
   }


### PR DESCRIPTION
Korjattu organisaatiopalvelun hierarkia-rajapinnan kutsut uuden jälkeläiset-rajapinnan kutsulla ja cachetuksella. Tämän pitäisi auttaa siihen, ettei organisaatiopalvelua enää pommiteta niin paljon esim. silloin, kun indeksointi kutsuu kouta-backendiä.