### PR TITLE
Kto 1036

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Kirjoitushetkellä käytössä openJDK8 (Java 11 käy myös) ja scala 2.12.10.
 
 Tähän on kaksi vaihtoehtoa, postgresin asentaminen omalle koneelle tai kontissa ajaminen.
 Näitä vaihtoehtoja voi hallita VM-parametreilla (katso ohjeet alempaa). 
-Oletuksena postgresia ajetaan host-koneella. Postgresin asennuksen tai kontti imagen buildin 
+Oletuksena postgresia ajetaan kontissa. Postgresin asennuksen tai kontti imagen buildin 
 jälkeen ei kannasta tarvitse huolehtia sillä sovellus ja testit huoletivat kannan käynnistämisestä 
 
 Kontti-imagen luonti (tarvitsee tehdä vain kerran)
@@ -81,13 +81,13 @@ jää paikoilleen, vaikka docker on jo sammunut. Silloin kannattaa ajaa `tools/s
 
 EmbeddedJettyLauncheria voidaan konfiguroida seuraavilla VM-parametreilla:
  
-| System property                                 |                                                                                           |   
-| ------------------------------------------------|:-----------------------------------------------------------------------------------------:|   
-| ```-Dkouta-backend.port=xxxx```                 | Määrittää Jettyn portin (default 8099)                                                    |   
-| ```-Dkouta-backend.embedded=xxxx```             | Käynnistetäänkö embedded PostgreSQL (default true)                                        |   
-| ```-Dkouta-backend.embeddedPostgresType=xxxx``` | Käynnistetäänkö PostgreSQL host-koneella vai kontissa (`host` tai `docker`, default host) |   
-| ```-Dkouta-backend.profile=xxxx```              | Määrittää profiilin                                                                       |   
-| ```-Dkouta-backend.template=xxxx```             | Määrittää template-tiedoston polun                                                        |   
+| System property                                 |                                                                                             |   
+| ------------------------------------------------|:-------------------------------------------------------------------------------------------:|   
+| ```-Dkouta-backend.port=xxxx```                 | Määrittää Jettyn portin (default 8099)                                                      |   
+| ```-Dkouta-backend.embedded=xxxx```             | Käynnistetäänkö embedded PostgreSQL (default true)                                          |   
+| ```-Dkouta-backend.embeddedPostgresType=xxxx``` | Käynnistetäänkö PostgreSQL host-koneella vai kontissa (`host` tai `docker`, default docker) |   
+| ```-Dkouta-backend.profile=xxxx```              | Määrittää profiilin                                                                         |   
+| ```-Dkouta-backend.template=xxxx```             | Määrittää template-tiedoston polun                                                          |   
 
 * Jos embedded Postgres ei ole käytössä, profiili voi olla joko *default* tai *template*
     * ```default```-profiilissa ```oph-configuration``` luetaan käyttäjän kotihakemistosta

--- a/kouta-backend/src/main/resources/db/migration/V56__remove_alkamisvuosi_from_haku.sql
+++ b/kouta-backend/src/main/resources/db/migration/V56__remove_alkamisvuosi_from_haku.sql
@@ -1,0 +1,2 @@
+alter table haut drop column alkamisvuosi;
+alter table haut_history drop column alkamisvuosi;

--- a/kouta-backend/src/main/resources/db/migration/V57__add_koulutuksenalkamiskausi_to_toteutus.sql
+++ b/kouta-backend/src/main/resources/db/migration/V57__add_koulutuksenalkamiskausi_to_toteutus.sql
@@ -1,0 +1,38 @@
+-- Luo tyhjän koulutuksen alkamiskauden jos jossakin vanhassa kentässä arvo
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI}', '{}', TRUE)
+where (metadata -> 'opetus' ->> 'koulutuksenTarkkaAlkamisaika' notnull or
+    metadata -> 'opetus' ->> 'koulutuksenAlkamispaivamaara' notnull or
+    metadata -> 'opetus' ->> 'koulutuksenPaattymispaivamaara' notnull or
+    metadata -> 'opetus' ->> 'koulutuksenAlkamiskausi' notnull or
+    metadata -> 'opetus' ->> 'koulutuksenAlkamisvuosi' notnull);
+
+-- päivittää tyypiksi "tarkka alkamisajankohta" jos vanha koulutuksenTarkkaAlkamisaika on true
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,alkamiskausityyppi}', '"tarkka alkamisajankohta"', TRUE)
+where (metadata -> 'opetus' ->> 'koulutuksenTarkkaAlkamisaika' notnull and metadata -> 'opetus' ->> 'koulutuksenTarkkaAlkamisaika' = 'true');
+
+-- päivittää tyypiksi "alkamiskausi ja -vuosi" jos vanha koulutuksenTarkkaAlkamisaika on false
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,alkamiskausityyppi}', '"alkamiskausi ja -vuosi"', TRUE)
+where (metadata -> 'opetus' ->> 'koulutuksenTarkkaAlkamisaika' = 'false');
+
+-- koulutuksen alkamiskausiKoodiUri vanhasta koulutuksenAlkamiskausi-kentästä
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamiskausiKoodiUri}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamiskausi'), TRUE)
+where metadata -> 'opetus' ->> 'koulutuksenAlkamiskausi' notnull;
+
+-- koulutuksen koulutuksenAlkamisvuosi vanhasta koulutuksenAlkamisvuosi-kentästä
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamisvuosi}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamisvuosi'), TRUE)
+where metadata -> 'opetus' ->> 'koulutuksenAlkamisvuosi' notnull;
+
+-- koulutuksen koulutuksenAlkamispaivamaara vanhasta koulutuksenAlkamispaivamaara-kentästä
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamispaivamaara}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamispaivamaara'), TRUE)
+where metadata -> 'opetus' ->> 'koulutuksenAlkamispaivamaara' notnull;
+
+-- koulutuksen koulutuksenPaattymispaivamaara vanhasta koulutuksenPaattymispaivamaara-kentästä
+update toteutukset
+set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenPaattymispaivamaara}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenPaattymispaivamaara'), TRUE)
+where metadata -> 'opetus' ->> 'koulutuksenPaattymispaivamaara' notnull;

--- a/kouta-backend/src/main/resources/db/migration/V57__add_koulutuksenalkamiskausi_to_toteutus.sql
+++ b/kouta-backend/src/main/resources/db/migration/V57__add_koulutuksenalkamiskausi_to_toteutus.sql
@@ -17,22 +17,22 @@ update toteutukset
 set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,alkamiskausityyppi}', '"alkamiskausi ja -vuosi"', TRUE)
 where (metadata -> 'opetus' ->> 'koulutuksenTarkkaAlkamisaika' = 'false');
 
--- koulutuksen alkamiskausiKoodiUri vanhasta koulutuksenAlkamiskausi-kentästä
+-- kopioitu alkamiskausiKoodiUri vanhasta koulutuksenAlkamiskausi-kentästä
 update toteutukset
 set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamiskausiKoodiUri}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamiskausi'), TRUE)
 where metadata -> 'opetus' ->> 'koulutuksenAlkamiskausi' notnull;
 
--- koulutuksen koulutuksenAlkamisvuosi vanhasta koulutuksenAlkamisvuosi-kentästä
+-- kopioitu koulutuksenAlkamisvuosi vanhasta koulutuksenAlkamisvuosi-kentästä
 update toteutukset
 set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamisvuosi}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamisvuosi'), TRUE)
 where metadata -> 'opetus' ->> 'koulutuksenAlkamisvuosi' notnull;
 
--- koulutuksen koulutuksenAlkamispaivamaara vanhasta koulutuksenAlkamispaivamaara-kentästä
+-- kopioitu koulutuksenAlkamispaivamaara vanhasta koulutuksenAlkamispaivamaara-kentästä
 update toteutukset
 set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenAlkamispaivamaara}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenAlkamispaivamaara'), TRUE)
 where metadata -> 'opetus' ->> 'koulutuksenAlkamispaivamaara' notnull;
 
--- koulutuksen koulutuksenPaattymispaivamaara vanhasta koulutuksenPaattymispaivamaara-kentästä
+-- kopioitu koulutuksenPaattymispaivamaara vanhasta koulutuksenPaattymispaivamaara-kentästä
 update toteutukset
 set metadata = jsonb_set(metadata, '{opetus,koulutuksenAlkamiskausiUUSI,koulutuksenPaattymispaivamaara}', to_jsonb(metadata -> 'opetus' ->> 'koulutuksenPaattymispaivamaara'), TRUE)
 where metadata -> 'opetus' ->> 'koulutuksenPaattymispaivamaara' notnull;

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
@@ -420,8 +420,7 @@ package object domain {
       |        henkilokohtaisenSuunnitelmanLisatiedot:
       |          type: object
       |          description: Lisätietoa koulutuksen alkamisesta henkilökohtaisen suunnitelman mukaan eri kielillä. Kielet on määritetty haun kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Teksti'
+      |          $ref: '#/components/schemas/Teksti'
       |""".stripMargin
 
   val models = List(KieliModel, JulkaisutilaModel, TekstiModel, NimiModel, KuvausModel, LinkkiModel, LisatietoModel,

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
@@ -1,13 +1,12 @@
 package fi.oph.kouta
 
-import java.time.{Instant, LocalDateTime}
-import java.util.UUID
-
-import fi.oph.kouta.domain.{AlkamiskausiJaVuosi, Alkamiskausityyppi, Julkaisutila, Kieli, TarkkaAlkamisajankohta}
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.util.TimeUtils
-import fi.oph.kouta.validation.{IsValid, NoErrors, ValidatableSubEntity}
 import fi.oph.kouta.validation.Validations._
+import fi.oph.kouta.validation.{IsValid, NoErrors, ValidatableSubEntity}
+
+import java.time.{Instant, LocalDateTime}
+import java.util.UUID
 
 //Huom! Älä käytä enumeraatioita, koska Swagger ei tue niitä -> TODO: Voi ehkä käyttää, kun ei ole scalatra-swagger enää käytössä?!
 package object domain {

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
@@ -573,7 +573,7 @@ package object domain {
     override def validate(tila: Julkaisutila, kielivalinta: Seq[Kieli], path: String): IsValid = and(
       validateKoulutusPaivamaarat(koulutuksenAlkamispaivamaara, koulutuksenPaattymispaivamaara, s"$path.koulutuksenAlkamispaivamaara"),
       validateIfDefined[String](koulutuksenAlkamiskausiKoodiUri, assertMatch(_, KausiKoodiPattern, s"$path.koulutuksenAlkamiskausiKoodiUri")),
-      validateIfDefined[String](koulutuksenAlkamisvuosi, v => assertMatch(v.toString, VuosiPattern, s"$path.koulutuksenAlkamisvuosi")),
+      validateIfDefined[String](koulutuksenAlkamisvuosi, v => assertMatch(v, VuosiPattern, s"$path.koulutuksenAlkamisvuosi")),
       validateIfJulkaistu(tila, and(
         assertNotOptional(alkamiskausityyppi, s"$path.alkamiskausityyppi"),
         validateIfTrue(TarkkaAlkamisajankohta == alkamiskausityyppi.get, assertNotOptional(koulutuksenAlkamispaivamaara, s"$path.koulutuksenAlkamispaivamaara")),

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
@@ -585,7 +585,8 @@ package object domain {
 
     override def validateOnJulkaisu(path: String): IsValid = and(
       validateIfDefined[String](koulutuksenAlkamisvuosi, v => assertAlkamisvuosiInFuture(v, s"$path.alkamisvuosi")),
-      validateIfDefined[LocalDateTime](koulutuksenAlkamispaivamaara, assertInFuture(_, s"$path.koulutuksenAlkamispaivamaara")))
+      validateIfDefined[LocalDateTime](koulutuksenAlkamispaivamaara, assertInFuture(_, s"$path.koulutuksenAlkamispaivamaara")),
+      validateIfDefined[LocalDateTime](koulutuksenPaattymispaivamaara, assertInFuture(_, s"$path.koulutuksenPaattymispaivamaara")))
   }
 
   case class ListEverything(koulutukset: Seq[KoulutusOid] = Seq(),

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/package.scala
@@ -11,7 +11,7 @@ import java.util.UUID
 //Huom! Älä käytä enumeraatioita, koska Swagger ei tue niitä -> TODO: Voi ehkä käyttää, kun ei ole scalatra-swagger enää käytössä?!
 package object domain {
 
-  val KieliModel =
+  val KieliModel: String =
     """    Kieli:
       |      type: string
       |      enum:
@@ -20,7 +20,7 @@ package object domain {
       |        - en
       |""".stripMargin
 
-  val LiitteenToimitustapaModel =
+  val LiitteenToimitustapaModel: String =
     """    LiitteenToimitustapa:
       |      type: string
       |      enum:
@@ -29,7 +29,7 @@ package object domain {
       |        - lomake
       |""".stripMargin
 
-  val AjanjaksoModel =
+  val AjanjaksoModel: String =
     """    Ajanjakso:
       |      type: object
       |      properties:
@@ -45,7 +45,7 @@ package object domain {
       |           example: 2019-08-23T09:55
       |""".stripMargin
 
-  val JulkaisutilaModel =
+  val JulkaisutilaModel: String =
     """    Julkaisutila:
       |      type: string
       |      enum:
@@ -54,7 +54,7 @@ package object domain {
       |        - arkistoitu
       |""".stripMargin
 
-  val HakulomaketyyppiModel =
+  val HakulomaketyyppiModel: String =
     """    Hakulomaketyyppi:
       |      type: string
       |      enum:
@@ -63,7 +63,7 @@ package object domain {
       |        - muu
       |""".stripMargin
 
-  val TekstiModel =
+  val TekstiModel: String =
     """    Teksti:
       |      type: object
       |      properties:
@@ -81,7 +81,7 @@ package object domain {
       |          description: "Englanninkielinen teksti, jos kielivalinnassa on 'en'"
       |""".stripMargin
 
-  val NimiModel =
+  val NimiModel: String =
     """    Nimi:
       |      type: object
       |      properties:
@@ -99,7 +99,7 @@ package object domain {
       |          description: "Englanninkielinen nimi, jos kielivalinnassa on 'en'"
       |""".stripMargin
 
-  val KuvausModel =
+  val KuvausModel: String =
     """    Kuvaus:
       |      type: object
       |      properties:
@@ -117,7 +117,7 @@ package object domain {
       |          description: "Englanninkielinen kuvaus, jos kielivalinnassa on 'en'"
       |""".stripMargin
 
-  val LinkkiModel =
+  val LinkkiModel: String =
     """    Linkki:
       |      type: object
       |      properties:
@@ -135,7 +135,7 @@ package object domain {
       |          description: "Linkki englanninkieliselle sivulle, jos kielivalinnassa on 'en'"
       |""".stripMargin
 
-  val LisatietoModel =
+  val LisatietoModel: String =
     """    Lisatieto:
       |      type: object
       |      properties:
@@ -150,7 +150,7 @@ package object domain {
       |            - $ref: '#/components/schemas/Teksti'
       |""".stripMargin
 
-  val YhteyshenkiloModel =
+  val YhteyshenkiloModel: String =
     """    Yhteyshenkilo:
       |      type: object
       |      properties:
@@ -181,7 +181,7 @@ package object domain {
       |            - $ref: '#/components/schemas/Teksti'
       |""".stripMargin
 
-  val OsoiteModel =
+  val OsoiteModel: String =
     """    Osoite:
       |      type: object
       |      properties:
@@ -196,7 +196,7 @@ package object domain {
       |          example: "posti_04230#2"
       |""".stripMargin
 
-  val ValintakoeModel =
+  val ValintakoeModel: String =
     """    Valintakoe:
       |      type: object
       |      description: Valintakokeen tiedot
@@ -224,7 +224,7 @@ package object domain {
       |            $ref: '#/components/schemas/Valintakoetilaisuus'
       |""".stripMargin
 
-  val ValintakoeMetadataModel =
+  val ValintakoeMetadataModel: String =
     """    ValintakoeMetadata:
       |      type: object
       |      properties:
@@ -251,7 +251,7 @@ package object domain {
       |            - $ref: '#/components/schemas/Teksti'
       |""".stripMargin
 
-  val ValintakoetilaisuusModel =
+  val ValintakoetilaisuusModel: String =
     """    Valintakoetilaisuus:
       |      type: object
       |      properties:
@@ -277,7 +277,7 @@ package object domain {
       |            - $ref: '#/components/schemas/Teksti'
       |""".stripMargin
 
-  val ListEverythingModel =
+  val ListEverythingModel: String =
     """    ListEverything:
       |      type: object
       |      properties:
@@ -332,7 +332,7 @@ package object domain {
       |              - d9afdef2-ae7a-4e78-8366-ab8f97b1fd25
       |""".stripMargin
 
-  val AuthenticatedModel =
+  val AuthenticatedModel: String =
     """    Authenticated:
       |      type: object
       |      properties:
@@ -366,7 +366,7 @@ package object domain {
       |                    example: APP_KOUTA_OPHPAAKAYTTAJA_1.2.246.562.10.00000000001
       |""".stripMargin
 
-  val TutkinnonOsaModel =
+  val TutkinnonOsaModel: String =
     """    TutkinnonOsa:
       |      type: object
       |      properties:
@@ -388,7 +388,7 @@ package object domain {
       |          example: 2449201
       |""".stripMargin
 
-  val KoulutuksenAlkamiskausiModel =
+  val KoulutuksenAlkamiskausiModel: String =
     """    KoulutuksenAlkamiskausi:
       |      type: object
       |      properties:

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
@@ -59,6 +59,10 @@ package object toteutusMetadata {
       |          type: double
       |          description: "Koulutuksen toteutuksen maksun määrä euroissa?"
       |          example: 220.50
+      |        koulutuksenAlkamiskausiUUSI:
+      |          type: object
+      |          description: Koulutuksen alkamiskausi
+      |          $ref: '#/components/schemas/KoulutuksenAlkamiskausi'
       |        koulutuksenTarkkaAlkamisaika:
       |          type: string
       |          description: Jos alkamisaika on tiedossa niin alkamis- ja päättymispäivämäärä on pakollinen. Muussa tapauksessa kausi ja vuosi on pakollisia tietoja.
@@ -501,6 +505,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
                   onkoMaksullinen: Option[Boolean] = Some(false),
                   maksullisuusKuvaus: Kielistetty = Map(),
                   maksunMaara: Option[Double] = None,
+                  koulutuksenAlkamiskausiUUSI: Option[KoulutuksenAlkamiskausi] = None, //Feature flag KTO-1036, myos swagger skeema
                   koulutuksenTarkkaAlkamisaika: Option[Boolean] = None,
                   koulutuksenAlkamispaivamaara: Option[LocalDateTime] = None,
                   koulutuksenPaattymispaivamaara: Option[LocalDateTime] = None,
@@ -517,6 +522,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
     validateIfNonEmpty[String](opetuskieliKoodiUrit, s"$path.opetuskieliKoodiUrit", assertMatch(_, OpetuskieliKoodiPattern, _)),
     validateIfNonEmpty[String](opetusaikaKoodiUrit, s"$path.opetusaikaKoodiUrit", assertMatch(_, OpetusaikaKoodiPattern, _)),
     validateIfNonEmpty[String](opetustapaKoodiUrit, s"$path.opetustapaKoodiUrit", assertMatch(_, OpetustapaKoodiPattern, _)),
+    validateIfDefined[KoulutuksenAlkamiskausi](koulutuksenAlkamiskausiUUSI, _.validate(tila, kielivalinta, s"$path.koulutuksenAlkamiskausiUUSI")), //Feature flag KTO-1036
     validateIfDefined[String](koulutuksenAlkamiskausi, assertMatch(_, KausiKoodiPattern, s"$path.koulutuksenAlkamiskausi")),
     validateIfDefined[Int](koulutuksenAlkamisvuosi, v => assertMatch(v.toString, VuosiPattern, s"$path.koulutuksenAlkamisvuosi")),
     validateKoulutusPaivamaarat(koulutuksenAlkamispaivamaara, koulutuksenPaattymispaivamaara, s"$path.koulutuksenAlkamispaivamaara"),
@@ -539,6 +545,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
       validateIfTrue(onkoStipendia.contains(true), assertNotOptional(stipendinMaara, s"$path.stipendinMaara")),
       validateOptionalKielistetty(kielivalinta, stipendinKuvaus, s"$path.stipendinKuvaus"),
       validateOptionalKielistetty(kielivalinta, suunniteltuKestoKuvaus, s"$path.suunniteltuKestoKuvaus"),
+      assertNotOptional(koulutuksenAlkamiskausiUUSI, s"$path.koulutuksenAlkamiskausiUUSI"), //Feature flag KTO-1036
       validateIfDefined[Boolean](koulutuksenTarkkaAlkamisaika, _ match {
         case true  => assertNotOptional(koulutuksenAlkamispaivamaara, s"$path.koulutuksenAlkamispaivamaara")
         case false => and(
@@ -552,5 +559,6 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
   override def validateOnJulkaisu(path: String): IsValid = and(
     validateIfDefined[LocalDateTime](koulutuksenAlkamispaivamaara, assertInFuture(_, s"$path.koulutuksenAlkamispaivamaara")),
     validateIfDefined[LocalDateTime](koulutuksenPaattymispaivamaara, assertInFuture(_, s"$path.koulutuksenPaattymispaivamaara")),
+    validateIfDefined[KoulutuksenAlkamiskausi](koulutuksenAlkamiskausiUUSI, _.validateOnJulkaisu(s"$path.koulutuksenAlkamiskausiUUSI")) //Feature flag KTO-1036
   )
 }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
@@ -545,7 +545,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
       validateIfTrue(onkoStipendia.contains(true), assertNotOptional(stipendinMaara, s"$path.stipendinMaara")),
       validateOptionalKielistetty(kielivalinta, stipendinKuvaus, s"$path.stipendinKuvaus"),
       validateOptionalKielistetty(kielivalinta, suunniteltuKestoKuvaus, s"$path.suunniteltuKestoKuvaus"),
-      assertNotOptional(koulutuksenAlkamiskausiUUSI, s"$path.koulutuksenAlkamiskausiUUSI"), //Feature flag KTO-1036
+//      assertNotOptional(koulutuksenAlkamiskausiUUSI, s"$path.koulutuksenAlkamiskausiUUSI"), //Feature flag KTO-1036
       validateIfDefined[Boolean](koulutuksenTarkkaAlkamisaika, _ match {
         case true  => assertNotOptional(koulutuksenAlkamispaivamaara, s"$path.koulutuksenAlkamispaivamaara")
         case false => and(

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
@@ -545,7 +545,6 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
       validateIfTrue(onkoStipendia.contains(true), assertNotOptional(stipendinMaara, s"$path.stipendinMaara")),
       validateOptionalKielistetty(kielivalinta, stipendinKuvaus, s"$path.stipendinKuvaus"),
       validateOptionalKielistetty(kielivalinta, suunniteltuKestoKuvaus, s"$path.suunniteltuKestoKuvaus"),
-//      assertNotOptional(koulutuksenAlkamiskausiUUSI, s"$path.koulutuksenAlkamiskausiUUSI"), //Feature flag KTO-1036
       validateIfDefined[Boolean](koulutuksenTarkkaAlkamisaika, _ match {
         case true  => assertNotOptional(koulutuksenAlkamispaivamaara, s"$path.koulutuksenAlkamispaivamaara")
         case false => and(

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
@@ -505,11 +505,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
                   onkoMaksullinen: Option[Boolean] = Some(false),
                   maksullisuusKuvaus: Kielistetty = Map(),
                   maksunMaara: Option[Double] = None,
-                  koulutuksenTarkkaAlkamisaika: Option[Boolean] = None,
-                  koulutuksenAlkamispaivamaara: Option[LocalDateTime] = None,
-                  koulutuksenPaattymispaivamaara: Option[LocalDateTime] = None,
-                  koulutuksenAlkamiskausi: Option[String] = None,
-                  koulutuksenAlkamisvuosi: Option[Int] = None,
+                  koulutuksenAlkamiskausi: Option[KoulutuksenAlkamiskausi] = None,
                   lisatiedot: Seq[Lisatieto] = Seq(),
                   onkoStipendia: Option[Boolean] = Some(false),
                   stipendinMaara: Option[Double] = None,
@@ -521,9 +517,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
     validateIfNonEmpty[String](opetuskieliKoodiUrit, s"$path.opetuskieliKoodiUrit", assertMatch(_, OpetuskieliKoodiPattern, _)),
     validateIfNonEmpty[String](opetusaikaKoodiUrit, s"$path.opetusaikaKoodiUrit", assertMatch(_, OpetusaikaKoodiPattern, _)),
     validateIfNonEmpty[String](opetustapaKoodiUrit, s"$path.opetustapaKoodiUrit", assertMatch(_, OpetustapaKoodiPattern, _)),
-    validateIfDefined[String](koulutuksenAlkamiskausi, assertMatch(_, KausiKoodiPattern, s"$path.koulutuksenAlkamiskausi")),
-    validateIfDefined[Int](koulutuksenAlkamisvuosi, v => assertMatch(v.toString, VuosiPattern, s"$path.koulutuksenAlkamisvuosi")),
-    validateKoulutusPaivamaarat(koulutuksenAlkamispaivamaara, koulutuksenPaattymispaivamaara, s"$path.koulutuksenAlkamispaivamaara"),
+    validateIfDefined[KoulutuksenAlkamiskausi](koulutuksenAlkamiskausi, _.validate(tila, kielivalinta, s"$path.koulutuksenAlkamiskausi")),
     validateIfNonEmpty[Lisatieto](lisatiedot, s"$path.lisatiedot", _.validate(tila, kielivalinta, _)),
     validateIfDefined[Double](stipendinMaara, assertNotNegative(_, s"$path.stipendinMaara")),
     validateIfDefined[Double](maksunMaara, assertNotNegative(_, s"$path.maksunMaara")),
@@ -542,19 +536,7 @@ case class Opetus(opetuskieliKoodiUrit: Seq[String] = Seq(),
       assertNotOptional(onkoStipendia, s"$path.onkoStipendia"),
       validateIfTrue(onkoStipendia.contains(true), assertNotOptional(stipendinMaara, s"$path.stipendinMaara")),
       validateOptionalKielistetty(kielivalinta, stipendinKuvaus, s"$path.stipendinKuvaus"),
-      validateOptionalKielistetty(kielivalinta, suunniteltuKestoKuvaus, s"$path.suunniteltuKestoKuvaus"),
-      validateIfDefined[Boolean](koulutuksenTarkkaAlkamisaika, _ match {
-        case true  => assertNotOptional(koulutuksenAlkamispaivamaara, s"$path.koulutuksenAlkamispaivamaara")
-        case false => and(
-          assertNotOptional(koulutuksenAlkamiskausi, s"$path.koulutuksenAlkamiskausi"),
-          assertNotOptional(koulutuksenAlkamisvuosi, s"$path.koulutuksenAlkamisvuosi")
-        )
-      })
+      validateOptionalKielistetty(kielivalinta, suunniteltuKestoKuvaus, s"$path.suunniteltuKestoKuvaus")
     ))
-  )
-
-  override def validateOnJulkaisu(path: String): IsValid = and(
-    validateIfDefined[LocalDateTime](koulutuksenAlkamispaivamaara, assertInFuture(_, s"$path.koulutuksenAlkamispaivamaara")),
-    validateIfDefined[LocalDateTime](koulutuksenPaattymispaivamaara, assertInFuture(_, s"$path.koulutuksenPaattymispaivamaara")),
   )
 }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutusMetadata.scala
@@ -23,8 +23,7 @@ package object toteutusMetadata {
       |        opetuskieletKuvaus:
       |          type: object
       |          description: Koulutuksen toteutuksen opetuskieliä tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Kuvaus'
+      |          $ref: '#/components/schemas/Kuvaus'
       |        opetusaikaKoodiUrit:
       |          type: array
       |          description: Lista koulutuksen toteutuksen opetusajoista. Viittaa [koodistoon](https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodisto/opetusaikakk/1)
@@ -36,8 +35,7 @@ package object toteutusMetadata {
       |        opetusaikaKuvaus:
       |          type: object
       |          description: Koulutuksen toteutuksen opetusaikoja tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Kuvaus'
+      |          $ref: '#/components/schemas/Kuvaus'
       |        opetustapaKoodiUrit:
       |          type: array
       |          description: Lista koulutuksen toteutuksen opetustavoista. Viittaa [koodistoon](https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodisto/opetuspaikkakk/1)
@@ -49,16 +47,14 @@ package object toteutusMetadata {
       |        opetustapaKuvaus:
       |          type: object
       |          description: Koulutuksen toteutuksen opetustapoja tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Kuvaus'
+      |          $ref: '#/components/schemas/Kuvaus'
       |        onkoMaksullinen:
       |          type: boolean
       |          decription: "Onko koulutus maksullinen?"
       |        maksullisuusKuvaus:
       |          type: object
       |          description: Koulutuksen toteutuksen maksullisuutta tarkentava kuvausteksti eri kielillä. Kielet on määritetty koulutuksen kielivalinnassa.
-      |          allOf:
-      |            - $ref: '#/components/schemas/Kuvaus'
+      |          $ref: '#/components/schemas/Kuvaus'
       |        maksunMaara:
       |          type: double
       |          description: "Koulutuksen toteutuksen maksun määrä euroissa?"

--- a/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
@@ -11,26 +11,26 @@ import fi.oph.kouta.domain.oid._
 
 object TestData {
 
-  def now() = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
-  def inFuture(s:Long = 500) = LocalDateTime.now().plusSeconds(s).truncatedTo(ChronoUnit.MINUTES)
-  def inPast(s:Long = 500) = LocalDateTime.now().minusSeconds(s).truncatedTo(ChronoUnit.MINUTES)
+  def now(): LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+  def inFuture(s:Long = 500): LocalDateTime = LocalDateTime.now().plusSeconds(s).truncatedTo(ChronoUnit.MINUTES)
+  def inPast(s:Long = 500): LocalDateTime = LocalDateTime.now().minusSeconds(s).truncatedTo(ChronoUnit.MINUTES)
 
   def kieliMap(text: String): Kielistetty = Map(Fi -> s"$text fi", Sv -> s"$text sv")
 
   def getInvalidHakuajat = List(Ajanjakso(TestData.inFuture(9000), Some(TestData.inFuture(3000))))
 
-  val Osoite1 = Osoite(
+  val Osoite1: Osoite = Osoite(
     osoite = Map(Fi -> "Kivatie 1", Sv -> "kivavägen 1"),
     postinumeroKoodiUri = Some("posti_04230#2"))
 
-  val Yhteystieto1 = Yhteyshenkilo(
+  val Yhteystieto1: Yhteyshenkilo = Yhteyshenkilo(
     nimi = Map(Fi -> "Aku Ankka", Sv -> "Aku Ankka"),
     puhelinnumero = Map(Fi -> "123", Sv -> "123"),
     sahkoposti = Map(Fi -> "aku.ankka@ankkalinnankoulu.fi", Sv -> "aku.ankka@ankkalinnankoulu.fi"),
     titteli = Map(Fi -> "titteli", Sv -> "titteli sv"),
     wwwSivu = Map(Fi -> "http://opintopolku.fi", Sv -> "http://studieinfo.fi"))
 
-  val Liite1 = Liite(
+  val Liite1: Liite = Liite(
     id = None,
     tyyppiKoodiUri = Some("liitetyypitamm_2#1"),
     nimi = Map(Fi -> "liite 1 Fi", Sv -> "liite 1 Sv"),
@@ -39,7 +39,7 @@ object TestData {
     toimitustapa = Some(Hakijapalvelu),
     toimitusosoite = None)
 
-  val Liite2 = Liite(
+  val Liite2: Liite = Liite(
     id = None,
     tyyppiKoodiUri = Some("liitetyypitamm_1#1"),
     nimi = Map(Fi -> "liite 2 Fi", Sv -> "liite 2 Sv"),
@@ -48,7 +48,7 @@ object TestData {
     toimitustapa = Some(MuuOsoite),
     toimitusosoite = Some(LiitteenToimitusosoite(osoite = Osoite1, sahkoposti = Some("foo@bar.fi"))))
 
-  val Valintakoe1 = Valintakoe(
+  val Valintakoe1: Valintakoe = Valintakoe(
     id = None,
     tyyppiKoodiUri = Some("valintakokeentyyppi_1#1"),
     nimi = Map(Fi -> "valintakokeen nimi fi", Sv -> "valintakokeen nimi sv"),
@@ -64,7 +64,7 @@ object TestData {
       aika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture()))),
       lisatietoja = Map(Fi -> "lisätietieto fi", Sv -> "lisätieto sv"))))
 
-  val AmmKoulutus = Koulutus(
+  val AmmKoulutus: Koulutus = Koulutus(
     oid = None,
     johtaaTutkintoon = true,
     koulutustyyppi = Amm,
@@ -84,10 +84,10 @@ object TestData {
     ePerusteId = Some(11L),
     modified = None)
 
-  val Lisatieto1 = Lisatieto(otsikkoKoodiUri = "koulutuksenlisatiedot_03#1",
+  val Lisatieto1: Lisatieto = Lisatieto(otsikkoKoodiUri = "koulutuksenlisatiedot_03#1",
     teksti = Map(Fi -> "Opintojen lisätieto ", Sv -> "Opintojen lisätieto sv"))
 
-  val YoKoulutus = Koulutus(
+  val YoKoulutus: Koulutus = Koulutus(
     oid = None,
     johtaaTutkintoon = true,
     koulutustyyppi = Yo,
@@ -108,7 +108,7 @@ object TestData {
     ePerusteId = Some(12L),
     modified = None)
 
-  val AmmTutkinnonOsaKoulutus = Koulutus(
+  val AmmTutkinnonOsaKoulutus: Koulutus = Koulutus(
     oid = None,
     johtaaTutkintoon = false,
     koulutustyyppi = AmmTutkinnonOsa,
@@ -128,7 +128,7 @@ object TestData {
     ePerusteId = None,
     modified = None)
 
-  val AmmOsaamisalaKoulutus = AmmTutkinnonOsaKoulutus.copy(
+  val AmmOsaamisalaKoulutus: Koulutus = AmmTutkinnonOsaKoulutus.copy(
     koulutustyyppi = AmmOsaamisala,
     koulutusKoodiUri = Some("koulutus_371101#1"),
     ePerusteId = Some(11L),
@@ -138,7 +138,7 @@ object TestData {
       lisatiedot = Seq(Lisatieto1),
       osaamisalaKoodiUri = Some("osaamisala_01"))))
 
-  val MinKoulutus = Koulutus(
+  val MinKoulutus: Koulutus = Koulutus(
     koulutustyyppi = Amm,
     johtaaTutkintoon = false,
     muokkaaja = TestUserOid,
@@ -147,7 +147,7 @@ object TestData {
     nimi = kieliMap("Minimi koulutus"),
     modified = None)
 
-  val JulkaistuHaku = Haku(
+  val JulkaistuHaku: Haku = Haku(
     nimi = Map(Fi -> "Haku fi", Sv -> "Haku sv"),
     tila = Julkaistu,
     hakutapaKoodiUri = Some("hakutapa_03#1"),
@@ -176,14 +176,14 @@ object TestData {
     kielivalinta = Seq(Fi, Sv),
     modified = None)
 
-  val MinHaku = Haku(
+  val MinHaku: Haku = Haku(
     muokkaaja = TestUserOid,
     organisaatioOid = LonelyOid,
     kielivalinta = Seq(Fi, Sv),
     nimi = kieliMap("Minimi haku"),
     modified = None)
 
-  val JulkaistuHakukohde = Hakukohde(
+  val JulkaistuHakukohde: Hakukohde = Hakukohde(
     oid = None,
     toteutusOid = ToteutusOid("1.2.246.562.17.123"),
     hakuOid = HakuOid("1.2.246.562.29.123"),
@@ -219,7 +219,7 @@ object TestData {
     kielivalinta = Seq(Fi, Sv),
     modified = None)
 
-  val MinHakukohde = Hakukohde(
+  val MinHakukohde: Hakukohde = Hakukohde(
     muokkaaja = TestUserOid,
     organisaatioOid = ChildOid,
     kielivalinta = Seq(Fi, Sv),
@@ -228,7 +228,7 @@ object TestData {
     hakuOid = HakuOid("1.2.246.562.29.123"),
     modified = None)
 
-  val Taulukko1 = Taulukko(
+  val Taulukko1: Taulukko = Taulukko(
     id = None,
     nimi = Map(Fi -> "Taulukko 1", Sv -> "Taulukko 1 sv"),
     rows = Seq(
@@ -239,7 +239,7 @@ object TestData {
         Column(index = 0, text = Map(Fi -> "Tekstiä", Sv -> "Tekstiä sv")),
         Column(index = 1, text = Map(Fi -> "Tekstiä 2", Sv -> "Tekstiä 2 sv"))))))
 
-  val Taulukko2 = Taulukko(
+  val Taulukko2: Taulukko = Taulukko(
     id = None,
     nimi = Map(Fi -> "Taulukko 2", Sv -> "Taulukko 2 sv"),
     rows = Seq(
@@ -250,7 +250,7 @@ object TestData {
         Column(index = 0, text = Map(Fi -> "Tekstiä", Sv -> "Tekstiä sv")),
         Column(index = 1, text = Map(Fi -> "Tekstiä 2", Sv -> "Tekstiä 2 sv"))))))
 
-  val Valintatapa1 = Valintatapa(
+  val Valintatapa1: Valintatapa = Valintatapa(
     nimi = kieliMap("Valintatapa1"),
     valintatapaKoodiUri = Some("valintatapajono_av#1"),
     kuvaus = kieliMap("kuvaus"),
@@ -260,7 +260,7 @@ object TestData {
     enimmaispisteet = Some(201.15),
     vahimmaispisteet = Some(182.1))
 
-  val Valintatapa2 = Valintatapa(
+  val Valintatapa2: Valintatapa = Valintatapa(
     nimi = kieliMap("Valintatapa2"),
     valintatapaKoodiUri = Some("valintatapajono_tv#1"),
     kuvaus = kieliMap("kuvaus 2"),
@@ -270,7 +270,7 @@ object TestData {
     enimmaispisteet = Some(18.1),
     vahimmaispisteet = Some(10.1))
 
-  val Kielitaitovaatimus1 = ValintaperusteKielitaitovaatimus(
+  val Kielitaitovaatimus1: ValintaperusteKielitaitovaatimus = ValintaperusteKielitaitovaatimus(
     kieliKoodiUri = Some("kieli_en#1"),
     kielitaidonVoiOsoittaa = Seq(
       Kielitaito(kielitaitoKoodiUri = Some("kielitaidonosoittaminen_01#1") ),
@@ -292,20 +292,20 @@ object TestData {
             kielitaitovaatimusKuvausKoodiUri = Some("kielitaitovaatimustyypitkuvaus_02#1"),
             kielitaitovaatimusTaso = Some("A"))))))
 
-  val YoValintaperusteMetadata = YliopistoValintaperusteMetadata(
+  val YoValintaperusteMetadata: YliopistoValintaperusteMetadata = YliopistoValintaperusteMetadata(
     valintatavat = Seq(Valintatapa1, Valintatapa2),
     kielitaitovaatimukset = Seq(Kielitaitovaatimus1),
     osaamistaustaKoodiUrit = Seq("osaamistausta_001#1"),
     valintakokeidenYleiskuvaus = Map(Fi -> "yleiskuvaus fi", Sv -> "yleiskuvaus sv"),
     kuvaus = kieliMap("kuvaus"))
 
-  val AmmValintaperusteMetadata = AmmatillinenValintaperusteMetadata(
+  val AmmValintaperusteMetadata: AmmatillinenValintaperusteMetadata = AmmatillinenValintaperusteMetadata(
     valintatavat = Seq(Valintatapa1, Valintatapa2),
     kielitaitovaatimukset = Seq(Kielitaitovaatimus1),
     valintakokeidenYleiskuvaus = Map(Fi -> "yleiskuvaus fi", Sv -> "yleiskuvaus sv"),
     kuvaus = Map(Fi -> "kuvaus", Sv -> "kuvaus sv"))
 
-  val AmmValintaperuste = Valintaperuste(
+  val AmmValintaperuste: Valintaperuste = Valintaperuste(
     koulutustyyppi = Amm,
     id = None,
     tila = Julkaistu,
@@ -322,7 +322,7 @@ object TestData {
     kielivalinta = List(Fi, Sv),
     modified = None)
 
-  val YoValintaperuste = Valintaperuste(
+  val YoValintaperuste: Valintaperuste = Valintaperuste(
     koulutustyyppi = Yo,
     id = None,
     tila = Julkaistu,
@@ -339,7 +339,7 @@ object TestData {
     kielivalinta = List(Fi, Sv),
     modified = None)
 
-  val MinYoValintaperuste = Valintaperuste(
+  val MinYoValintaperuste: Valintaperuste = Valintaperuste(
     koulutustyyppi = Yo,
     kielivalinta = Seq(Fi, Sv),
     nimi = kieliMap("Minimi valintaperuste"),
@@ -347,7 +347,7 @@ object TestData {
     organisaatioOid = ChildOid,
     modified = None)
 
-  val YoSorakuvaus = Sorakuvaus(
+  val YoSorakuvaus: Sorakuvaus = Sorakuvaus(
     id = None,
     tila = Julkaistu,
     nimi = kieliMap("nimi"),
@@ -361,9 +361,9 @@ object TestData {
     muokkaaja = OphUserOid,
     modified = None)
 
-  val AmmSorakuvaus = YoSorakuvaus.copy(koulutustyyppi = Amm)
+  val AmmSorakuvaus: Sorakuvaus = YoSorakuvaus.copy(koulutustyyppi = Amm)
 
-  val MinSorakuvaus = Sorakuvaus(
+  val MinSorakuvaus: Sorakuvaus = Sorakuvaus(
     koulutustyyppi = Yo,
     kielivalinta = Seq(Fi, Sv),
     nimi = kieliMap("Minimi sorakuvaus"),
@@ -371,7 +371,7 @@ object TestData {
     organisaatioOid = OphOid,
     modified = None)
 
-  val ToteutuksenOpetus = Opetus(
+  val ToteutuksenOpetus: Opetus = Opetus(
     opetuskieliKoodiUrit = Seq("oppilaitoksenopetuskieli_1#1"),
     opetuskieletKuvaus = Map(Fi -> "Kielikuvaus fi", Sv -> "Kielikuvaus sv"),
     opetusaikaKoodiUrit = Seq("opetusaikakk_1#1"),
@@ -397,7 +397,7 @@ object TestData {
     suunniteltuKestoKuvaus = Map(Fi -> "Keston kuvaus fi", Sv -> "Keston kuvaus sv")
   )
 
-  val AmmToteutuksenMetatieto = AmmatillinenToteutusMetadata(
+  val AmmToteutuksenMetatieto: AmmatillinenToteutusMetadata = AmmatillinenToteutusMetadata(
     kuvaus = Map(),
     osaamisalat = List(AmmatillinenOsaamisala("osaamisala_0001#1",
       linkki = Map(Fi -> "http://osaamisala.fi/linkki/fi", Sv -> "http://osaamisala.fi/linkki/sv"),
@@ -407,7 +407,7 @@ object TestData {
     ammattinimikkeet = List(Keyword(Fi, "insinööri"), Keyword(Fi, "koneinsinööri")),
     yhteyshenkilot = Seq(Yhteystieto1))
 
-  val YoToteutuksenMetatieto = YliopistoToteutusMetadata(
+  val YoToteutuksenMetatieto: YliopistoToteutusMetadata = YliopistoToteutusMetadata(
     kuvaus = Map(),
     alemmanKorkeakoulututkinnonOsaamisalat = Seq(KorkeakouluOsaamisala(
       linkki = Map(Fi -> "http://osaamisala.fi/linkki/fi", Sv -> "http://osaamisala.fi/linkki/sv"),
@@ -424,7 +424,7 @@ object TestData {
     ammattinimikkeet = List(Keyword(Fi, "insinööri"), Keyword(Fi, "koneinsinööri")),
     yhteyshenkilot = Seq(Yhteystieto1))
 
-  val JulkaistuAmmToteutus = Toteutus(
+  val JulkaistuAmmToteutus: Toteutus = Toteutus(
     oid = None,
     koulutusOid = KoulutusOid("1.2.246.562.13.123"),
     tila = Julkaistu,
@@ -436,9 +436,9 @@ object TestData {
     kielivalinta = Seq(Fi, Sv),
     modified = None)
 
-  val JulkaistuYoToteutus = JulkaistuAmmToteutus.copy(metadata = Some(YoToteutuksenMetatieto))
+  val JulkaistuYoToteutus: Toteutus = JulkaistuAmmToteutus.copy(metadata = Some(YoToteutuksenMetatieto))
 
-  val MinToteutus = Toteutus(
+  val MinToteutus: Toteutus = Toteutus(
     muokkaaja = TestUserOid,
     organisaatioOid = ChildOid,
     koulutusOid = KoulutusOid("1.2.246.562.13.123"),
@@ -446,7 +446,7 @@ object TestData {
     nimi = kieliMap("Minimi toteutus"),
     modified = None)
 
-  val AmmOsaamisalaToteutus = JulkaistuAmmToteutus.copy(
+  val AmmOsaamisalaToteutus: Toteutus = JulkaistuAmmToteutus.copy(
     metadata = Some(AmmatillinenOsaamisalaToteutusMetadata(
       tyyppi = AmmOsaamisala,
       kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
@@ -462,7 +462,7 @@ object TestData {
       hakuaika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture()))),
       aloituspaikat = Some(23))))
 
-  val AmmOsaamisalaToteutusMetadataHakemuspalvelu = AmmatillinenOsaamisalaToteutusMetadata(
+  val AmmOsaamisalaToteutusMetadataHakemuspalvelu: AmmatillinenOsaamisalaToteutusMetadata = AmmatillinenOsaamisalaToteutusMetadata(
     tyyppi = AmmOsaamisala,
     kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
     opetus = Some(ToteutuksenOpetus),
@@ -477,7 +477,7 @@ object TestData {
     hakuaika = None,
     aloituspaikat = Some(23))
 
-  val AmmOsaamisalaToteutusMetadataEiSahkoista = AmmatillinenOsaamisalaToteutusMetadata(
+  val AmmOsaamisalaToteutusMetadataEiSahkoista: AmmatillinenOsaamisalaToteutusMetadata = AmmatillinenOsaamisalaToteutusMetadata(
     tyyppi = AmmOsaamisala,
     kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
     opetus = Some(ToteutuksenOpetus),
@@ -492,7 +492,7 @@ object TestData {
     hakuaika = None,
     aloituspaikat = Some(23))
 
-  val AmmTutkinnonOsaToteutus = JulkaistuAmmToteutus.copy(
+  val AmmTutkinnonOsaToteutus: Toteutus = JulkaistuAmmToteutus.copy(
     metadata = Some(AmmatillinenTutkinnonOsaToteutusMetadata(
       tyyppi = AmmTutkinnonOsa,
       kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
@@ -508,7 +508,7 @@ object TestData {
       hakuaika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture()))),
       aloituspaikat = Some(22))))
 
-  val AmmTutkinnonOsaToteutusMetadataHakemuspalvelu = AmmatillinenTutkinnonOsaToteutusMetadata(
+  val AmmTutkinnonOsaToteutusMetadataHakemuspalvelu: AmmatillinenTutkinnonOsaToteutusMetadata = AmmatillinenTutkinnonOsaToteutusMetadata(
     tyyppi = AmmTutkinnonOsa,
     kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
     opetus = Some(ToteutuksenOpetus),
@@ -523,7 +523,7 @@ object TestData {
     hakuaika = None,
     aloituspaikat = Some(23))
 
-  val AmmTutkinnonOsaToteutusMetadataEiSahkoista = AmmatillinenTutkinnonOsaToteutusMetadata(
+  val AmmTutkinnonOsaToteutusMetadataEiSahkoista: AmmatillinenTutkinnonOsaToteutusMetadata = AmmatillinenTutkinnonOsaToteutusMetadata(
     tyyppi = AmmTutkinnonOsa,
     kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
     opetus = Some(ToteutuksenOpetus),
@@ -538,7 +538,7 @@ object TestData {
     hakuaika = None,
     aloituspaikat = Some(23))
 
-  val JulkaistuOppilaitos = Oppilaitos(
+  val JulkaistuOppilaitos: Oppilaitos = Oppilaitos(
     oid = ChildOid,
     tila = Julkaistu,
     metadata = Some(OppilaitosMetadata(
@@ -563,14 +563,14 @@ object TestData {
     muokkaaja = TestUserOid,
     modified = None)
 
-  val MinOppilaitos = Oppilaitos(
+  val MinOppilaitos: Oppilaitos = Oppilaitos(
     oid = ChildOid,
     tila = Tallennettu,
     organisaatioOid = ChildOid,
     kielivalinta = Seq(Fi, Sv),
     muokkaaja = TestUserOid)
 
-  val JulkaistuOppilaitoksenOsa = OppilaitoksenOsa(
+  val JulkaistuOppilaitoksenOsa: OppilaitoksenOsa = OppilaitoksenOsa(
     oid = GrandChildOid,
     oppilaitosOid = ChildOid,
     tila = Julkaistu,
@@ -588,7 +588,7 @@ object TestData {
     muokkaaja = TestUserOid,
     modified = None)
 
-  val MinOppilaitoksenOsa = OppilaitoksenOsa(
+  val MinOppilaitoksenOsa: OppilaitoksenOsa = OppilaitoksenOsa(
     oid = GrandChildOid,
     oppilaitosOid = ChildOid,
     tila = Tallennettu,

--- a/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
@@ -381,6 +381,13 @@ object TestData {
     onkoMaksullinen = Some(true),
     maksullisuusKuvaus = Map(Fi -> "Maksullisuuskuvaus fi", Sv -> "Maksullisuuskuvaus sv"),
     maksunMaara = Some(200.5),
+    koulutuksenAlkamiskausiUUSI = Some(KoulutuksenAlkamiskausi(
+      alkamiskausityyppi = Some(AlkamiskausiJaVuosi),
+      henkilokohtaisenSuunnitelmanLisatiedot = Map(Fi -> "Jotakin lisätietoa", Sv -> "Jotakin lisätietoa sv"),
+      koulutuksenAlkamispaivamaara = None,
+      koulutuksenPaattymispaivamaara = None,
+      koulutuksenAlkamiskausiKoodiUri = Some("kausi_k#1"),
+      koulutuksenAlkamisvuosi = Some(LocalDate.now().getYear.toString))),
     koulutuksenTarkkaAlkamisaika = Some(true),
     koulutuksenAlkamispaivamaara = Some(inFuture(20000)),
     koulutuksenPaattymispaivamaara = Some(inFuture(30000)),

--- a/kouta-backend/src/test/scala/fi/oph/kouta/embeddedJettyLauncher.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/embeddedJettyLauncher.scala
@@ -72,9 +72,9 @@ object TestSetups extends Logging with KoutaConfigurationConstants {
 
   def setupWithEmbeddedPostgres(): String = {
     logger.info("Starting embedded PostgreSQL!")
-    System.getProperty("kouta-backend.embeddedPostgresType", "host") match {
-      case x if "docker".equalsIgnoreCase(x) => startDockerPostgres()
-      case _ => startHostPostgres()
+    System.getProperty("kouta-backend.embeddedPostgresType", "docker") match {
+      case x if "host".equalsIgnoreCase(x) => startHostPostgres()
+      case _ => startDockerPostgres()
     }
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -216,7 +216,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     MockAuditLogger.clean()
-    update(thisToteutus, lastModified, false)
+    update(thisToteutus, lastModified, expectUpdate = false)
     MockAuditLogger.logs shouldBe empty
     get(oid, thisToteutus)
   }
@@ -278,7 +278,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val oid = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, false, crudSessions(toteutus.organisaatioOid))
+    update(thisToteutus, lastModified, expectUpdate = false, crudSessions(toteutus.organisaatioOid))
   }
 
   it should "deny a user without access to the toteutus organization" in {
@@ -292,14 +292,14 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val oid = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, false, crudSessions(ParentOid))
+    update(thisToteutus, lastModified, expectUpdate = false, crudSessions(ParentOid))
   }
 
   it should "allow a user with only access to a descendant organization" in {
     val oid = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, false, crudSessions(GrandChildOid))
+    update(thisToteutus, lastModified, expectUpdate = false, crudSessions(GrandChildOid))
   }
 
   it should "allow a user of the tarjoaja organization to update the toteutus" in {
@@ -307,7 +307,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val oid = put(toteutus(newKoulutusOid).copy(tarjoajat = List(LonelyOid)))
     val thisToteutus = toteutus(oid, newKoulutusOid).copy(tarjoajat = List(LonelyOid))
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, false, crudSessions(LonelyOid))
+    update(thisToteutus, lastModified, expectUpdate = false, crudSessions(LonelyOid))
   }
 
   it should "deny a user with the wrong role" in {
@@ -352,7 +352,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
       nimi = Map(Fi -> "kiva nimi", Sv -> "nimi sv", En -> "nice name"),
       metadata = Some(ammMetatieto.copy(kuvaus = Map(Fi -> "kuvaus", Sv -> "kuvaus sv", En -> "description"))),
       tarjoajat = List(LonelyOid, OtherOid, AmmOid))
-    update(uusiToteutus, lastModified, true)
+    update(uusiToteutus, lastModified, expectUpdate = true)
     get(oid, uusiToteutus)
   }
 
@@ -362,12 +362,12 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val lastModified = get(oid, thisToteutus)
     Thread.sleep(1500)
     val uusiToteutus = thisToteutus.copy(tarjoajat = List())
-    update(uusiToteutus, lastModified, true)
-    get(oid, uusiToteutus) should not equal (lastModified)
+    update(uusiToteutus, lastModified, expectUpdate = true)
+    get(oid, uusiToteutus) should not equal lastModified
   }
 
   it should "store and update unfinished toteutus" in {
-    val unfinishedToteutus = new Toteutus(muokkaaja = TestUserOid, koulutusOid = KoulutusOid(koulutusOid), organisaatioOid = ChildOid, modified = None, kielivalinta = Seq(Fi), nimi = Map(Fi -> "toteutus"))
+    val unfinishedToteutus = Toteutus(muokkaaja = TestUserOid, koulutusOid = KoulutusOid(koulutusOid), organisaatioOid = ChildOid, modified = None, kielivalinta = Seq(Fi), nimi = Map(Fi -> "toteutus"))
     val oid = put(unfinishedToteutus)
     val lastModified = get(oid, unfinishedToteutus.copy(oid = Some(ToteutusOid(oid))))
     val newKoulutusOid = put(koulutus)
@@ -557,7 +557,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "extract toteutus from JSON of correct form" in {
     val toteutus: Toteutus = ToteutusJsonMethods.extractJsonString(correctJson)
-    toteutus.metadata.isDefined shouldBe(true)
+    toteutus.metadata.isDefined shouldBe true
   }
 
   it should "fail to extract toteutus from JSON of incorrect form" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -482,10 +482,24 @@ class ToteutusSpec extends KoutaIntegrationSpec
     update(thisToteutusWithOid.copy(tila = Arkistoitu), lastModified)
   }
 
-
+  //feature flag KTO-1036 remove this test
   it should "not validate dates when updating a julkaistu toteutus" in {
     val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
     val inPastOpetus = opetus.copy(koulutuksenAlkamispaivamaara = Some(morePast), koulutuksenPaattymispaivamaara = Some(past))
+    val inPastMetadata = ammMetatieto.copy(opetus = Some(inPastOpetus))
+
+    val oid = put(toteutus(koulutusOid).copy(tila = Julkaistu))
+    val thisToteutus = toteutus(oid, koulutusOid)
+
+    val lastModified = get(oid, thisToteutus)
+
+    update(thisToteutus.copy(metadata = Some(inPastMetadata)), lastModified)
+  }
+
+  //feature flag KTO-1036
+  it should "not validate dates when updating a julkaistu toteutus UUSI" in {
+    val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
+    val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = morePast, paattymispvm = past))
     val inPastMetadata = ammMetatieto.copy(opetus = Some(inPastOpetus))
 
     val oid = put(toteutus(koulutusOid).copy(tila = Julkaistu))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -555,15 +555,6 @@ class ToteutusSpec extends KoutaIntegrationSpec
     }
   }
 
-  it should "extract toteutus from JSON of correct form" in {
-    val toteutus: Toteutus = ToteutusJsonMethods.extractJsonString(correctJson)
-    toteutus.metadata.isDefined shouldBe true
-  }
-
-  it should "fail to extract toteutus from JSON of incorrect form" in {
-    an [org.json4s.MappingException] shouldBe thrownBy(ToteutusJsonMethods.extractJsonString(incorrectJson))
-  }
-
   val correctJson: String = """{
     "oid": "1.2.246.562.17.00000000000000000067",
     "koulutusOid": "1.2.246.562.13.00000000000000000167",
@@ -607,6 +598,11 @@ class ToteutusSpec extends KoutaIntegrationSpec
     ],
     "modified": "2019-10-29T15:21"
   }"""
+
+  it should "extract toteutus from JSON of correct form" in {
+    val toteutus: Toteutus = ToteutusJsonMethods.extractJsonString(correctJson)
+    toteutus.metadata.isDefined shouldBe true
+  }
 
   val incorrectJson: String = """{
     "oid": "1.2.246.562.17.00000000000000000067",
@@ -652,6 +648,10 @@ class ToteutusSpec extends KoutaIntegrationSpec
     ],
     "modified": "2019-10-29T15:21"
   }"""
+
+  it should "fail to extract toteutus from JSON of incorrect form" in {
+    an [org.json4s.MappingException] shouldBe thrownBy(ToteutusJsonMethods.extractJsonString(incorrectJson))
+  }
 
   "When tutkintoon johtamaton, toteutus servlet" should "create, get and update ammatillinen osaamisala toteutus" in {
     val sorakuvausId = put(sorakuvaus)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -417,7 +417,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
   it should "validate dates only when adding a new julkaistu toteutus UUSI" in { //feature flag KTO-1036
     val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
 
-    val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(past, morePast))
+    val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = morePast, paattymispvm = past))
     val thisToteutus = toteutus(koulutusOid).copy(metadata = Some(ammMetatieto.copy(opetus = Some(inPastOpetus))), tila = Julkaistu)
 
     put(thisToteutus.copy(tila = Tallennettu))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -415,7 +415,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   //feature flag KTO-1036
-  it should "validate dates only when adding a new julkaistu toteutus UUSI" in {
+  it should "validate koulutuksen alkamisen dates only when adding a new julkaistu toteutus UUSI" in {
     val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
 
     val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = morePast, paattymispvm = past))
@@ -459,7 +459,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   //feature flag KTO-1036
-  it should "validate dates when moving from other states to julkaistu UUSI" in {
+  it should "validate koulutuksen alkamisen dates when moving from other states to julkaistu UUSI" in {
     val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
     val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = morePast, paattymispvm = past))
     val thisToteutus = toteutus(koulutusOid).copy(metadata = Some(ammMetatieto.copy(opetus = Some(inPastOpetus))), tila = Tallennettu)
@@ -497,7 +497,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   //feature flag KTO-1036
-  it should "not validate dates when updating a julkaistu toteutus UUSI" in {
+  it should "not validate koulutuksen alkamisen dates when updating a julkaistu toteutus UUSI" in {
     val (past, morePast) = (TestData.inPast(5000), TestData.inPast(60000))
     val inPastOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = morePast, paattymispvm = past))
     val inPastMetadata = ammMetatieto.copy(opetus = Some(inPastOpetus))
@@ -508,6 +508,21 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val lastModified = get(oid, thisToteutus)
 
     update(thisToteutus.copy(metadata = Some(inPastMetadata)), lastModified)
+  }
+
+  //feature flag KTO-1036
+  it should "allow missing koulutuksen alkamiskausi" in {
+    val (future, morefuture) = (TestData.inFuture(5000), TestData.inFuture(6000))
+
+    val futureOpetus = opetus.copy(koulutuksenAlkamiskausiUUSI = pastAlkamiskausi(alkamispvm = future, paattymispvm = morefuture))
+    val toteutusMetadata = Some(ammMetatieto.copy(opetus = Some(futureOpetus)))
+    val toteutusOid = put(toteutus(koulutusOid).copy(metadata = toteutusMetadata, tila = Julkaistu))
+
+    val copyOfJulkaistuToteutus = toteutus(toteutusOid, koulutusOid).copy(metadata = toteutusMetadata, tila = Julkaistu)
+    val lastModified = get(toteutusOid, copyOfJulkaistuToteutus)
+
+    val toteutusWithoutAlkamiskausi = copyOfJulkaistuToteutus.copy(metadata = Some(ammMetatieto.copy(opetus = Some(opetus.copy(koulutuksenAlkamiskausiUUSI = None)))))
+    update(toteutusWithoutAlkamiskausi, lastModified)
   }
 
   it should "copy a temporary image to a permanent location while updating the toteutus" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/validation/hakuValidationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/validation/hakuValidationSpec.scala
@@ -180,6 +180,17 @@ class HakuMetadataValidatorSpec extends SubEntityValidationSpec[HakuMetadata] {
     failsOnJulkaisuValidation(metadata.copy(koulutuksenAlkamiskausi = Some(alkamiskausiTarkka.copy(koulutuksenAlkamispaivamaara = Some(pastDate)))), "koulutuksenAlkamiskausi.koulutuksenAlkamispaivamaara", pastDateMsg(pastDate))
   }
 
+  it should "fail if paattymispaiva is in the past on julkaisu" in {
+    val (pastDate, evenMorePast) = (TestData.inPast(300), TestData.inPast(700))
+    val alkaminenAndPaattyminenInThePast = Some(alkamiskausiTarkka.copy(koulutuksenPaattymispaivamaara = Some(pastDate), koulutuksenAlkamispaivamaara = Some(evenMorePast)))
+
+    passesValidation(Julkaistu, metadata.copy(koulutuksenAlkamiskausi = alkaminenAndPaattyminenInThePast))
+    failsOnJulkaisuValidation(
+      metadata.copy(koulutuksenAlkamiskausi = alkaminenAndPaattyminenInThePast),
+      ("koulutuksenAlkamiskausi.koulutuksenAlkamispaivamaara", pastDateMsg(evenMorePast)),
+      ("koulutuksenAlkamiskausi.koulutuksenPaattymispaivamaara", pastDateMsg(pastDate)))
+  }
+
   it should "validate henkilökohtainen suunnitelma" in {
     val alkamiskausi = KoulutuksenAlkamiskausi(
       alkamiskausityyppi = Some(HenkilökohtainenSuunnitelma),

--- a/kouta-backend/src/test/scala/fi/oph/kouta/validation/hakuValidationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/validation/hakuValidationSpec.scala
@@ -11,10 +11,10 @@ import fi.oph.kouta.validation.Validations._
 
 class HakuValidationSpec extends BaseValidationSpec[Haku] {
 
-  val max = JulkaistuHaku
-  val min = MinHaku
-  val pastAjanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = Some(TestData.inPast(100)))
-  val onlyAlkaaAjanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = None)
+  val max: Haku = JulkaistuHaku
+  val min: Haku = MinHaku
+  val pastAjanjakso: Ajanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = Some(TestData.inPast(100)))
+  val onlyAlkaaAjanjakso: Ajanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = None)
 
   it should "fail if perustiedot is invalid" in {
     failsValidation(max.copy(oid = Some(HakuOid("moikka"))), "oid", validationMsg("moikka"))
@@ -93,8 +93,8 @@ class HakuValidationSpec extends BaseValidationSpec[Haku] {
 }
 
 class HakuMetadataValidatorSpec extends SubEntityValidationSpec[HakuMetadata] {
-  val metadata = JulkaistuHaku.metadata.get
-  val pastAjanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = Some(TestData.inPast(100)))
+  val metadata: HakuMetadata = JulkaistuHaku.metadata.get
+  val pastAjanjakso: Ajanjakso = Ajanjakso(alkaa = TestData.inPast(2000), paattyy = Some(TestData.inPast(100)))
 
   "HakuMetadata validation" should "pass a valid haku metadata" in {
     passesValidation(Julkaistu, metadata)
@@ -114,7 +114,7 @@ class HakuMetadataValidatorSpec extends SubEntityValidationSpec[HakuMetadata] {
     failsValidation(Julkaistu, metadata.copy(koulutuksenAlkamiskausi = None), "koulutuksenAlkamiskausi", missingMsg)
   }
 
-  val alkamiskausiJaVuosi = KoulutuksenAlkamiskausi(
+  val alkamiskausiJaVuosi: KoulutuksenAlkamiskausi = KoulutuksenAlkamiskausi(
     alkamiskausityyppi = Some(AlkamiskausiJaVuosi),
     koulutuksenAlkamispaivamaara = None,
     koulutuksenPaattymispaivamaara = None,
@@ -151,7 +151,7 @@ class HakuMetadataValidatorSpec extends SubEntityValidationSpec[HakuMetadata] {
     failsOnJulkaisuValidation(metadata.copy(koulutuksenAlkamiskausi = Some(alkamiskausiJaVuosi.copy(koulutuksenAlkamisvuosi = Some("2017")))), "koulutuksenAlkamiskausi.alkamisvuosi", pastDateMsg("2017"))
   }
 
-  val alkamiskausiTarkka = KoulutuksenAlkamiskausi(
+  val alkamiskausiTarkka: KoulutuksenAlkamiskausi = KoulutuksenAlkamiskausi(
     alkamiskausityyppi = Some(TarkkaAlkamisajankohta),
     koulutuksenAlkamispaivamaara = Some(TestData.now()),
     koulutuksenPaattymispaivamaara = Some(TestData.inFuture(300)),

--- a/kouta-backend/src/test/scala/fi/oph/kouta/validation/toteutusValidationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/validation/toteutusValidationSpec.scala
@@ -3,18 +3,20 @@ package fi.oph.kouta.validation
 import fi.oph.kouta.TestData
 import fi.oph.kouta.TestData._
 import fi.oph.kouta.domain._
-import fi.oph.kouta.domain.oid.{KoulutusOid, OrganisaatioOid, ToteutusOid, UserOid}
+import fi.oph.kouta.domain.oid.{KoulutusOid, OrganisaatioOid, ToteutusOid}
 import fi.oph.kouta.validation.Validations._
+
+import java.time.LocalDateTime
 
 class ToteutusValidationSpec extends BaseValidationSpec[Toteutus] {
 
-  val amm = JulkaistuAmmToteutus
-  val ammMetadata = AmmToteutuksenMetatieto
-  val yo = JulkaistuYoToteutus
-  val yoMetadata = YoToteutuksenMetatieto
-  val min = MinToteutus
-  val ammOa = AmmOsaamisalaToteutus
-  val ammTo = AmmTutkinnonOsaToteutus
+  val amm: Toteutus = JulkaistuAmmToteutus
+  val ammMetadata: AmmatillinenToteutusMetadata = AmmToteutuksenMetatieto
+  val yo: Toteutus = JulkaistuYoToteutus
+  val yoMetadata: YliopistoToteutusMetadata = YoToteutuksenMetatieto
+  val min: Toteutus = MinToteutus
+  val ammOa: Toteutus = AmmOsaamisalaToteutus
+  val ammTo: Toteutus = AmmTutkinnonOsaToteutus
 
   it should "fail if perustiedot is invalid" in {
     failsValidation(amm.copy(oid = Some(ToteutusOid("1.2.3"))), "oid", validationMsg("1.2.3"))
@@ -116,10 +118,10 @@ class ToteutusValidationSpec extends BaseValidationSpec[Toteutus] {
 }
 
 class OpetusValidationSpec extends SubEntityValidationSpec[Opetus] {
-  val opetus = ToteutuksenOpetus
+  val opetus: Opetus = ToteutuksenOpetus
 
-  val past = TestData.inPast(1000)
-  val moreInPast = TestData.inPast(9000)
+  val past: LocalDateTime = TestData.inPast(1000)
+  val moreInPast: LocalDateTime = TestData.inPast(9000)
 
   "Opetus validation" should "pass a valid opetus" in {
     passesValidation(Julkaistu, opetus)


### PR DESCRIPTION
- Lisätty toteutukselle koulutuksenAlkamiskausi-rakenne metadataan. Käytetään väliaikaista nimeä joka tullaan myöhemmin nimeämään uusiksi. Tämä mahdollistaa sen että kouta-backend voidaan asentaa itsenäisesti. 
- Vaihdettu docker-kontti postgresin oletus ajoalustaksi.
- Poistettu haut-taulusta alkamisvuosi, joka oli jo aiemmin poistettu domain-oliosta
- Pieniä refaktorointeja
