### PR TITLE
Kto 1184

### DIFF
--- a/kouta-backend/src/main/resources/db/migration/V72__remove_koulutuskoodiuri_from_koulutus.sql
+++ b/kouta-backend/src/main/resources/db/migration/V72__remove_koulutuskoodiuri_from_koulutus.sql
@@ -1,0 +1,43 @@
+alter table koulutukset drop column koulutus_koodi_uri;
+alter table koulutukset_history drop column koulutus_koodi_uri;
+
+create or replace function update_koulutukset_history() returns trigger
+    language plpgsql
+as
+$$
+begin
+    insert into koulutukset_history (oid,
+                                     johtaa_tutkintoon,
+                                     tyyppi,
+                                     koulutukset_koodi_uri,
+                                     tila,
+                                     nimi,
+                                     metadata,
+                                     muokkaaja,
+                                     transaction_id,
+                                     system_time,
+                                     kielivalinta,
+                                     organisaatio_oid,
+                                     esikatselu,
+                                     julkinen,
+                                     teemakuva,
+                                     eperuste_id)
+    values (old.oid,
+            old.johtaa_tutkintoon,
+            old.tyyppi,
+            old.koulutukset_koodi_uri,
+            old.tila,
+            old.nimi,
+            old.metadata,
+            old.muokkaaja,
+            old.transaction_id,
+            tstzrange(lower(old.system_time), now(), '[)'),
+            old.kielivalinta,
+            old.organisaatio_oid,
+            old.esikatselu,
+            old.julkinen,
+            old.teemakuva,
+            old.eperuste_id);
+    return null;
+end;
+$$;

--- a/kouta-backend/src/test/scala/fi/oph/kouta/validation/SorakuvausValidationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/validation/SorakuvausValidationSpec.scala
@@ -1,14 +1,13 @@
 package fi.oph.kouta.validation
 
 import fi.oph.kouta.TestData.{MinSorakuvaus, YoSorakuvaus}
-import fi.oph.kouta.domain.oid.UserOid
-import fi.oph.kouta.domain.{Fi, Sorakuvaus, SorakuvausMetadata, Sv, Tallennettu}
+import fi.oph.kouta.domain.{Fi, Sorakuvaus, Sv, Tallennettu}
 import fi.oph.kouta.validation.Validations._
 
 class SorakuvausValidationSpec extends BaseValidationSpec[Sorakuvaus] {
 
-  val max = YoSorakuvaus
-  val min = MinSorakuvaus
+  val max: Sorakuvaus = YoSorakuvaus
+  val min: Sorakuvaus = MinSorakuvaus
 
   it should "fail if perustiedot is invalid" in {
     failsValidation(min.copy(kielivalinta = Seq()), "kielivalinta", missingMsg)


### PR DESCRIPTION
- Poistettu koulutukselta tietokannasta koulutusKoodiUri kenttä. Koulutuksella on nykyään lista koulutusKoodiUreja ja tämä muutos on asennettu tuotantoon, joten vanha kenttä voidaan poistaa
- Pientä refaktorointia