### PR TITLE
Kto 1278

### DIFF
--- a/kouta-backend/src/main/scala/fi/oph/kouta/validation/Validations.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/validation/Validations.scala
@@ -49,7 +49,7 @@ object Validations {
   val KohdejoukkoKoodiPattern: Pattern = Pattern.compile("""haunkohdejoukko_\d+#\d{1,2}""")
   val KohdejoukonTarkenneKoodiPattern: Pattern = Pattern.compile("""haunkohdejoukontarkenne_\d+#\d{1,2}""")
   val PohjakoulutusvaatimusKoodiPattern: Pattern = Pattern.compile("""pohjakoulutusvaatimuskouta_\w+#\d{1,2}""")
-  val ValintatapajonoKoodiPattern: Pattern = Pattern.compile("""valintatapajono_\w{2}#\d{1,2}""")
+  val ValintatapajonoKoodiPattern: Pattern = Pattern.compile("""valintatapajono_\w{1,2}#\d{1,2}""")
   val KoulutuksenLisatiedotOtsikkoKoodiPattern: Pattern = Pattern.compile("""koulutuksenlisatiedot_\d+#\d{1,2}""")
   val TietoaOpiskelustaOtsikkoKoodiPattern: Pattern = Pattern.compile("""organisaationkuvaustiedot_\d+#\d{1,2}""")
   val KoulutusalaKoodiPattern: Pattern = Pattern.compile("""kansallinenkoulutusluokitus2016koulutusalataso[12]_\d+#\d{1,2}""")

--- a/kouta-backend/src/test/scala/fi/oph/kouta/validation/valintaperusteMetadataValidationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/validation/valintaperusteMetadataValidationSpec.scala
@@ -25,4 +25,9 @@ class ValintaperusteMetadataValidationSpec extends SubEntityValidationSpec[Valin
     passesValidation(Tallennettu, AmmValintaperusteMetadata.copy(lisatiedot = Map(Fi -> "lisatiedot")))
     failsValidation(Julkaistu, AmmValintaperusteMetadata.copy(lisatiedot = Map(Fi -> "lisatiedot")), "lisatiedot", invalidKielistetty(Seq(Sv)))
   }
+
+  it should "should allow muu valintatapa" in {
+    val muuValintatapa = Valintatapa1.copy(valintatapaKoodiUri = Some("valintatapajono_m#1"))
+    passesValidation(Tallennettu, YoValintaperusteMetadata.copy(valintatavat = Seq(muuValintatapa)))
+  }
 }


### PR DESCRIPTION
Sallitaan valintatapajonokoodin validoivassa regexpissä koodin kohdalla vain yksi kirjain. Valintatapa muu on tällainen.