### PR TITLE
KTO-1423: Search-rajapintojen parannuksia (etusivun listoja varten)

### DIFF
--- a/kouta-backend/pom.xml
+++ b/kouta-backend/pom.xml
@@ -7,10 +7,10 @@
     <parent>
         <groupId>fi.oph.kouta</groupId>
         <artifactId>kouta-backend-parent</artifactId>
-        <version>6.21.0-SNAPSHOT</version>
+        <version>6.21.1-SNAPSHOT</version>
     </parent>
     <artifactId>kouta-backend</artifactId>
-    <version>6.21.0-SNAPSHOT</version>
+    <version>6.21.1-SNAPSHOT</version>
     <name>kouta-backend</name>
 
     <properties>

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
@@ -404,6 +404,7 @@ case class KoulutusSearchItem (oid: KoulutusOid,
                                modified: Modified,
                                tila: Julkaisutila,
                                koulutustyyppi: Koulutustyyppi,
+                               julkinen: Option[Boolean] = None,
                                eperuste: Option[EPeruste] = None,
                                toteutusCount: Int = 0) extends KoulutusItemCommon
 
@@ -414,6 +415,7 @@ case class KoulutusSearchItemFromIndex (oid: KoulutusOid,
                                         modified: Modified,
                                         tila: Julkaisutila,
                                         koulutustyyppi: Koulutustyyppi,
+                                        julkinen: Option[Boolean] = None,
                                         eperuste: Option[EPeruste] = None,
                                         toteutukset: Seq[KoulutusSearchItemToteutus] = Seq()) extends KoulutusItemCommon
 
@@ -535,7 +537,8 @@ case class ValintaperusteSearchItem(id: UUID,
                                     muokkaaja: Muokkaaja,
                                     modified: Modified,
                                     tila: Julkaisutila,
-                                    koulutustyyppi: Koulutustyyppi)
+                                    koulutustyyppi: Koulutustyyppi,
+                                    julkinen: Option[Boolean] = None)
 
 case class Organisaatio(oid: OrganisaatioOid,
                         nimi: Kielistetty,

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
@@ -403,6 +403,7 @@ case class KoulutusSearchItem (oid: KoulutusOid,
                                muokkaaja: Muokkaaja,
                                modified: Modified,
                                tila: Julkaisutila,
+                               koulutustyyppi: Koulutustyyppi,
                                eperuste: Option[EPeruste] = None,
                                toteutusCount: Int = 0) extends KoulutusItemCommon
 
@@ -412,6 +413,7 @@ case class KoulutusSearchItemFromIndex (oid: KoulutusOid,
                                         muokkaaja: Muokkaaja,
                                         modified: Modified,
                                         tila: Julkaisutila,
+                                        koulutustyyppi: Koulutustyyppi,
                                         eperuste: Option[EPeruste] = None,
                                         toteutukset: Seq[KoulutusSearchItemToteutus] = Seq()) extends KoulutusItemCommon
 
@@ -448,6 +450,7 @@ case class ToteutusSearchItem(oid: ToteutusOid,
                               muokkaaja: Muokkaaja,
                               modified: Modified,
                               tila: Julkaisutila,
+                              koulutustyyppi: Koulutustyyppi,
                               hakukohdeCount: Int = 0) extends ToteutusItemCommon
 
 case class ToteutusSearchItemFromIndex(oid: ToteutusOid,
@@ -456,6 +459,7 @@ case class ToteutusSearchItemFromIndex(oid: ToteutusOid,
                                        muokkaaja: Muokkaaja,
                                        modified: Modified,
                                        tila: Julkaisutila,
+                                       koulutustyyppi: Koulutustyyppi,
                                        organisaatiot: Seq[String] = Seq(),
                                        hakukohteet: Seq[ToteutusSearchItemHakukohde] = Seq()) extends ToteutusItemCommon
 
@@ -519,7 +523,8 @@ case class HakukohdeSearchItem(oid: HakukohdeOid,
                                organisaatio: Organisaatio,
                                muokkaaja: Muokkaaja,
                                modified: Modified,
-                               tila: Julkaisutila)
+                               tila: Julkaisutila,
+                               koulutustyyppi: Koulutustyyppi)
 
 case class ValintaperusteSearchResult(totalCount: Int = 0,
                                       result: Seq[ValintaperusteSearchItem] = Seq())
@@ -529,7 +534,8 @@ case class ValintaperusteSearchItem(id: UUID,
                                     organisaatio: Organisaatio,
                                     muokkaaja: Muokkaaja,
                                     modified: Modified,
-                                    tila: Julkaisutila)
+                                    tila: Julkaisutila,
+                                    koulutustyyppi: Koulutustyyppi)
 
 case class Organisaatio(oid: OrganisaatioOid,
                         nimi: Kielistetty,

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
@@ -450,7 +450,7 @@ case class ToteutusSearchItem(oid: ToteutusOid,
                               muokkaaja: Muokkaaja,
                               modified: Modified,
                               tila: Julkaisutila,
-                              koulutustyyppi: Koulutustyyppi,
+                              koulutustyyppi: Option[Koulutustyyppi] = None,
                               hakukohdeCount: Int = 0) extends ToteutusItemCommon
 
 case class ToteutusSearchItemFromIndex(oid: ToteutusOid,
@@ -459,7 +459,7 @@ case class ToteutusSearchItemFromIndex(oid: ToteutusOid,
                                        muokkaaja: Muokkaaja,
                                        modified: Modified,
                                        tila: Julkaisutila,
-                                       koulutustyyppi: Koulutustyyppi,
+                                       koulutustyyppi: Option[Koulutustyyppi] = None,
                                        organisaatiot: Seq[String] = Seq(),
                                        hakukohteet: Seq[ToteutusSearchItemHakukohde] = Seq()) extends ToteutusItemCommon
 
@@ -524,7 +524,7 @@ case class HakukohdeSearchItem(oid: HakukohdeOid,
                                muokkaaja: Muokkaaja,
                                modified: Modified,
                                tila: Julkaisutila,
-                               koulutustyyppi: Koulutustyyppi)
+                               koulutustyyppi: Option[Koulutustyyppi] = None)
 
 case class ValintaperusteSearchResult(totalCount: Int = 0,
                                       result: Seq[ValintaperusteSearchItem] = Seq())

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/searchResults.scala
@@ -518,7 +518,7 @@ case class HakuSearchItemHakukohde(oid: HakukohdeOid,
                                    organisaatio: Organisaatio)
 
 case class HakukohdeSearchResult(totalCount: Int = 0,
-                                 result: Seq[HakuSearchItem] = Seq())
+                                 result: Seq[HakukohdeSearchItem] = Seq())
 
 case class HakukohdeSearchItem(oid: HakukohdeOid,
                                nimi: Kielistetty,

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/KoulutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/KoulutusService.scala
@@ -232,6 +232,7 @@ class KoulutusService(
               modified = k.modified,
               tila = k.tila,
               eperuste = k.eperuste,
+              julkinen = k.julkinen,
               koulutustyyppi = k.koulutustyyppi,
               toteutusCount = getCount(k, organisaatioOids)
             )

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/KoulutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/KoulutusService.scala
@@ -232,6 +232,7 @@ class KoulutusService(
               modified = k.modified,
               tila = k.tila,
               eperuste = k.eperuste,
+              koulutustyyppi = k.koulutustyyppi,
               toteutusCount = getCount(k, organisaatioOids)
             )
           }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -143,6 +143,7 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
                   muokkaaja = t.muokkaaja,
                   modified = t.modified,
                   tila = t.tila,
+                  koulutustyyppi = t.koulutustyyppi,
                   hakukohdeCount = getCount(t, organisaatioOids))
             }
           )

--- a/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
@@ -13,11 +13,10 @@ class SearchServlet(koulutusService: KoulutusService,
 
   def this() = this(KoulutusService, ToteutusService, HakuService, HakukohdeService, ValintaperusteService)
 
-  val SearchParams = Seq("nimi", "muokkaaja", "tila", "page", "size", "lng", "order-by", "order")
+  val SearchParams = Seq("nimi", "koulutustyyppi", "muokkaaja", "tila", "page", "size", "lng", "order-by", "order")
 
   val searchParams =
-    """      parameters:
-      |        - in: query
+    """        - in: query
       |          name: organisaatioOid
       |          schema:
       |            type: string
@@ -91,6 +90,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee organisaation koulutukset annetuilla parametreilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':
@@ -119,6 +126,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee rikastetun koulutuksen annetulla oidilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':
@@ -146,6 +161,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee organisaation toteutukset annetuilla parametreilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':
@@ -174,6 +197,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee rikastetun toteutuksen annetulla oidilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':
@@ -201,6 +232,7 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee organisaation haut annetuilla parametreilla
        |      tags:
        |        - Search
+       |      parameters:
        |$searchParams
        |      responses:
        |        '200':
@@ -229,6 +261,7 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee rikastetun haun annetulla oidilla
        |      tags:
        |        - Search
+       |      parameters:
        |$searchParams
        |      responses:
        |        '200':
@@ -256,6 +289,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee organisaation hakukohteet annetuilla parametreilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':
@@ -284,6 +325,14 @@ class SearchServlet(koulutusService: KoulutusService,
        |      description: Hakee organisaation valintaperustekuvaukset annetuilla parametreilla
        |      tags:
        |        - Search
+       |      parameters:
+       |        - in: query
+       |          name: koulutustyyppi
+       |          schema:
+       |            type: string
+       |          required: false
+       |          description: Suodata koulutustyypillä
+       |          example: yo
        |$searchParams
        |      responses:
        |        '200':

--- a/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
@@ -41,9 +41,11 @@ class SearchServlet(koulutusService: KoulutusService,
       |        - in: query
       |          name: tila
       |          schema:
-      |            type: string
+      |            type: array
+      |            items:
+      |              type: string
       |          required: false
-      |          description: Suodata tilalla (julkaistu/tallennettu/arkistoitu)
+      |          description: Suodata pilkulla erotetuilla tiloilla (julkaistu/tallennettu/arkistoitu/poistettu)
       |          example: Julkaistu
       |        - in: query
       |          name: page

--- a/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/servlet/SearchServlet.scala
@@ -13,7 +13,7 @@ class SearchServlet(koulutusService: KoulutusService,
 
   def this() = this(KoulutusService, ToteutusService, HakuService, HakukohdeService, ValintaperusteService)
 
-  val SearchParams = Seq("nimi", "muokkaaja", "tila", "arkistoidut", "page", "size", "lng", "order-by", "order")
+  val SearchParams = Seq("nimi", "muokkaaja", "tila", "page", "size", "lng", "order-by", "order")
 
   val searchParams =
     """      parameters:
@@ -45,13 +45,6 @@ class SearchServlet(koulutusService: KoulutusService,
       |          required: false
       |          description: Suodata tilalla (julkaistu/tallennettu/arkistoitu)
       |          example: Julkaistu
-      |        - in: query
-      |          name: arkistoidut
-      |          schema:
-      |            type: boolean
-      |          required: false
-      |          description: Näytetäänkö arkistoidut
-      |          example: true
       |        - in: query
       |          name: page
       |          schema:

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/SearchSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/SearchSpec.scala
@@ -22,7 +22,7 @@ class SearchSpec extends KoutaIntegrationSpec with AccessControlSpec with Everyt
   var hkoid1, hkoid2, hkoid3, hkoid4, hkoid5: String = _
   var vpid1, vpid2, vpid3, vpid4, vpid5: String = _
 
-  val params = Map("nimi" -> "Hassu", "page" -> "1")
+  val params = Map("nimi" -> "Hassu", "page" -> "1", "koulutustyyppi" -> "amm")
 
   def barams(organisaatioOid: OrganisaatioOid): Map[String, String] = params + ("organisaatioOid" -> organisaatioOid.s)
   def mockParams(oids: List[String]): Map[String, String] = params + ("oids" -> oids.map(_.toString).sorted.mkString(","))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/mocks/KoutaIndexMock.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/mocks/KoutaIndexMock.scala
@@ -35,6 +35,7 @@ trait KoutaIndexMock extends ServiceMocks with KoutaJsonFormats {
      "oid": "1.2.246.562.24.62301161440"
     },
     "modified": "2019-02-08T09:57:23",
+    "koulutustyyppi": "amm",
     "$idField": "$id",
     "tila": "julkaistu""""
 

--- a/kouta-common/pom.xml
+++ b/kouta-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fi.oph.kouta</groupId>
         <artifactId>kouta-backend-parent</artifactId>
-        <version>6.21.0-SNAPSHOT</version>
+        <version>6.21.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kouta-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>fi.oph.kouta</groupId>
     <artifactId>kouta-backend-parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.21.0-SNAPSHOT</version>
+    <version>6.21.1-SNAPSHOT</version>
     <name>kouta-backend-parent</name>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Utility properties -->
-        <scala-utils.version>1.2.2-SNAPSHOT</scala-utils.version>
+        <scala-utils.version>1.2.3-SNAPSHOT</scala-utils.version>
         <scala-logging.version>1.3.0-SNAPSHOT</scala-logging.version>
         <auditlogger.version>8.3.1-SNAPSHOT</auditlogger.version>
         <json4s.version>3.6.7</json4s.version>


### PR DESCRIPTION
Lisätty koulutustyyppi ja julkinen kentät search-rajapintoihin.
Poistettu myös "arkistoitu"-parametri.