### PR TITLE
Oy 3683

### DIFF
--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/HakukohdeService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/HakukohdeService.scala
@@ -138,8 +138,8 @@ class HakukohdeService(
           oid = hk.oid.get, status = "success", created = CopyOids(Some(hakukohdeCopyOid), Some(toteutusCopyOid))
         )
       } catch {
-        case error => {
-          logger.error(s"Copying hakukohde failed: ${error}")
+        case error: Throwable => {
+          logger.error(s"Copying hakukohde failed: $error")
           HakukohdeCopyResultObject(
             oid = hk.oid.get, status = "error", created = CopyOids(None, None)
           )

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -54,7 +54,7 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
     (toteutus.metadata, toteutus.koulutusMetadata) match {
       case (Some(toteutusMetadata), Some(koulutusMetadata)) =>
         (toteutusMetadata, koulutusMetadata) match {
-          case (lukioToteutusMetadata: LukioToteutusMetadata, lukioKoulutusMetadata: LukioKoulutusMetadata) => {
+          case (lukioToteutusMetadata: LukioToteutusMetadata, lukioKoulutusMetadata: LukioKoulutusMetadata) =>
             val kaannokset = Map(
               "yleiset.opintopistetta" -> lokalisointiClient.getKaannoksetWithKey("yleiset.opintopistetta"),
               "toteutuslomake.lukionYleislinjaNimiOsa" -> lokalisointiClient.getKaannoksetWithKey(
@@ -70,7 +70,6 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
               kaannokset,
               koodistoKaannokset
             )
-          }
           case _ => toteutus.nimi
         }
       case _ => toteutus.nimi
@@ -107,12 +106,11 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
   def get(oid: ToteutusOid, tilaFilter: TilaFilter)(implicit authenticated: Authenticated): Option[(Toteutus, Instant)] = {
     val toteutusWithTime = ToteutusDAO.get(oid, tilaFilter)
     val enrichedToteutus = toteutusWithTime match {
-      case Some((t, i)) => {
+      case Some((t, i)) =>
         val esitysnimi = generateToteutusEsitysnimi(t)
         val muokkaaja = oppijanumerorekisteriClient.getHenkilö(t.muokkaaja)
         val muokkaajanNimi = NameHelper.generateMuokkaajanNimi(muokkaaja)
         Some(t.withEnrichedData(ToteutusEnrichedData(esitysnimi, Some(muokkaajanNimi))).withoutRelatedData(), i)
-      }
       case None => None
     }
     authorizeGet(enrichedToteutus, AuthorizationRules(roleEntity.readRoles, allowAccessToParentOrganizations = true, additionalAuthorizedOrganisaatioOids = getTarjoajat(toteutusWithTime)))
@@ -223,12 +221,11 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
     def filterHakukohteet(toteutus: Option[ToteutusSearchItemFromIndex]): Option[ToteutusSearchItemFromIndex] =
       withAuthorizedOrganizationOids(organisaatioOid, AuthorizationRules(Role.Toteutus.readRoles, allowAccessToParentOrganizations = true)) {
         case Seq(RootOrganisaatioOid) => toteutus
-        case organisaatioOids => {
+        case organisaatioOids =>
           toteutus.flatMap(toteutusItem => {
             val oidStrings = organisaatioOids.map(_.toString())
             Some(toteutusItem.copy(hakukohteet = toteutusItem.hakukohteet.filter(hakukohde => oidStrings.contains(hakukohde.organisaatio.oid.toString()))))
           })
-        }
       }
 
     filterHakukohteet(KoutaIndexClient.searchToteutukset(Seq(toteutusOid), params).result.headOption)

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -139,10 +139,9 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
         val createdToteutusOid = put(toteutusCopyAsLuonnos)
         ToteutusCopyResultObject(oid = toteutus.oid.get, status = "success", created = ToteutusCopyOids(Some(createdToteutusOid)))
       } catch {
-        case error => {
-          logger.error(s"Copying toteutus failed: ${error}")
+        case error: Throwable =>
+          logger.error(s"Copying toteutus failed: $error")
           ToteutusCopyResultObject(oid = toteutus.oid.get, status = "error", created = ToteutusCopyOids(None))
-        }
       }
     })
   }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -264,7 +264,7 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
     ))
   }
 
-  private def validateHakukohdeIntegrityIfDeletingToteutus(aiempiTila: Julkaisutila, tulevaTila: Julkaisutila, toteutusOid: ToteutusOid) = {
+  private def validateHakukohdeIntegrityIfDeletingToteutus(aiempiTila: Julkaisutila, tulevaTila: Julkaisutila, toteutusOid: ToteutusOid): Unit = {
     throwValidationErrors(
       validateIfTrue(tulevaTila == Poistettu && tulevaTila != aiempiTila, assertTrue(
         HakukohdeDAO.listByToteutusOid(toteutusOid, TilaFilter.onlyOlemassaolevat()).isEmpty,
@@ -321,7 +321,7 @@ class ToteutusService(sqsInTransactionService: SqsInTransactionService,
   private def insertAmmattinimikkeet(toteutus: Toteutus)(implicit authenticated: Authenticated) =
     keywordService.insert(Ammattinimike, toteutus.metadata.map(_.ammattinimikkeet).getOrElse(Seq()))
 
-  def getOidsByTarjoajat(jarjestyspaikkaOids: Seq[OrganisaatioOid], tilaFilter: TilaFilter)(implicit authenticated: Authenticated) =
+  def getOidsByTarjoajat(jarjestyspaikkaOids: Seq[OrganisaatioOid], tilaFilter: TilaFilter)(implicit authenticated: Authenticated): Seq[ToteutusOid] =
     withRootAccess(indexerRoles) {
       ToteutusDAO.getOidsByTarjoajat(jarjestyspaikkaOids, tilaFilter)
     }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -2,7 +2,7 @@ package fi.oph.kouta.service
 
 import java.time.Instant
 import fi.oph.kouta.auditlog.AuditLog
-import fi.oph.kouta.client.{KayttooikeusClient, KoodistoClient, KoodistoKaannosClient, KoutaIndexClient, LokalisointiClient, OppijanumerorekisteriClient}
+import fi.oph.kouta.client.{KayttooikeusClient, KoodistoKaannosClient, KoutaIndexClient, LokalisointiClient, OppijanumerorekisteriClient}
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.keyword.{Ammattinimike, Asiasana}
 import fi.oph.kouta.domain.oid.{OrganisaatioOid, RootOrganisaatioOid, ToteutusOid}
@@ -11,7 +11,7 @@ import fi.oph.kouta.indexing.SqsInTransactionService
 import fi.oph.kouta.indexing.indexing.{HighPriority, IndexTypeToteutus}
 import fi.oph.kouta.repository.{HakuDAO, HakukohdeDAO, KoulutusDAO, KoutaDatabase, ToteutusDAO}
 import fi.oph.kouta.security.{Role, RoleEntity}
-import fi.oph.kouta.servlet.Authenticated
+import fi.oph.kouta.servlet.{Authenticated, EntityNotFoundException}
 import fi.oph.kouta.util.{NameHelper, ServiceUtils}
 import fi.oph.kouta.validation.{IsValid, NoErrors, Validations}
 import fi.oph.kouta.validation.Validations.{assertTrue, integrityViolationMsg, validateIfTrue, validateStateChange}
@@ -28,10 +28,10 @@ case class ToteutusCopyOids(
                    )
 
 case class ToteutusCopyResultObject(
-                                      oid: ToteutusOid,
-                                      status: String,
-                                      created: ToteutusCopyOids
-                                    )
+                                     oid: ToteutusOid,
+                                     status: String,
+                                     created: ToteutusCopyOids
+                                   )
 
 class ToteutusService(sqsInTransactionService: SqsInTransactionService,
                       val s3ImageService: S3ImageService,

--- a/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/service/ToteutusService.scala
@@ -1,7 +1,5 @@
 package fi.oph.kouta.service
 
-import com.hubspot.jinjava.lib.filter.ListFilter
-
 import java.time.Instant
 import fi.oph.kouta.auditlog.AuditLog
 import fi.oph.kouta.client.{KayttooikeusClient, KoodistoClient, KoodistoKaannosClient, KoutaIndexClient, LokalisointiClient, OppijanumerorekisteriClient}

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ExternalSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ExternalSpec.scala
@@ -25,7 +25,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
     "koulutus",
     ExternalKoulutusPath,
     (oid: String, authenticated: Authenticated) =>
-      ExternalKoulutusRequest(authenticated, createKoulutus(oid, tila = Some(Tallennettu))),
+      ExternalKoulutusRequest(authenticated, createKoulutus(oid, tila = Some(Arkistoitu))),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createKoulutus(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
   )
@@ -40,7 +40,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
     "toteutus",
     ExternalToteutusPath,
     (oid: String, authenticated: Authenticated) =>
-      ExternalToteutusRequest(authenticated, createToteutus(oid, tila = Some(Tallennettu))),
+      ExternalToteutusRequest(authenticated, createToteutus(oid, tila = Some(Arkistoitu))),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createToteutus(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
   )
@@ -55,7 +55,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
     "haku",
     ExternalHakuPath,
     (oid: String, authenticated: Authenticated) =>
-      ExternalHakuRequest(authenticated, createHaku(oid, tila = Some(Tallennettu))),
+      ExternalHakuRequest(authenticated, createHaku(oid, tila = Some(Arkistoitu))),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createHaku(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
   )
@@ -70,7 +70,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
     "hakukohde",
     ExternalHakukohdePath,
     (oid: String, authenticated: Authenticated) =>
-      ExternalHakukohdeRequest(authenticated, createHakukohde(oid, tila = Some(Tallennettu))),
+      ExternalHakukohdeRequest(authenticated, createHakukohde(oid, tila = Some(Arkistoitu))),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createHakukohde(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
   )
@@ -86,7 +86,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
     "valintaperuste",
     ExternalValintaperustePath,
     (oid: String, authenticated: Authenticated) =>
-      ExternalValintaperusteRequest(authenticated, createValintaperuste(oid, tila = Some(Tallennettu))),
+      ExternalValintaperusteRequest(authenticated, createValintaperuste(oid, tila = Some(Arkistoitu))),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createValintaperuste(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
   )
@@ -120,7 +120,7 @@ class ExternalSpec extends ExternalFixture with CreateTests with ModifyTests {
               .asInstanceOf[ExternalSession]
               .copy(authorities = Set(Authority(Role.Paakayttaja, OphOid)))
           ),
-        createSorakuvaus(oid, tila = Some(Tallennettu))
+        createSorakuvaus(oid, tila = Some(Arkistoitu))
       ),
     (oid: String, muokkaaja: Option[UserOid], tila: Option[Julkaisutila], isMuokkaajaOphVirkailija: Option[Boolean]) =>
       createSorakuvaus(oid, muokkaaja, tila, isMuokkaajaOphVirkailija)
@@ -203,7 +203,7 @@ trait ModifyTests extends TestBase {
       val request = makeModifyRequest(oidOrId, authenticated())
 
       doUpdate(request, lastModified, externalSession)
-      doGet(oidOrId, resultEntity(oidOrId, Some(TestUserOid), Some(Tallennettu), Some(false)))
+      doGet(oidOrId, resultEntity(oidOrId, Some(TestUserOid), Some(Arkistoitu), Some(false)))
     }
 
     it should s"require authentication to be attached to the request when updating existing $entityName" in {
@@ -223,7 +223,7 @@ trait ModifyTests extends TestBase {
       val request        = makeModifyRequest(oidOrId, authentication)
 
       doUpdate(request, lastModified, externalSession)
-      doGet(oidOrId, resultEntity(oidOrId, Some(userOid), Some(Tallennettu), Some(false)))
+      doGet(oidOrId, resultEntity(oidOrId, Some(userOid), Some(Arkistoitu), Some(false)))
     }
 
     it should s"deny a user with the wrong role when updating existing $entityName" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ExternalSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ExternalSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import fi.oph.kouta.TestOids
 import fi.oph.kouta.TestOids.{OphOid, TestUserOid}
 import fi.oph.kouta.domain.oid.{KoulutusOid, OrganisaatioOid, UserOid}
-import fi.oph.kouta.domain.{ExternalHakuRequest, ExternalHakukohdeRequest, ExternalKoulutusRequest, ExternalRequest, ExternalSorakuvausRequest, ExternalToteutusRequest, ExternalValintaperusteRequest, Haku, Hakukohde, Julkaisutila, Koulutus, Sorakuvaus, Tallennettu, Toteutus, Valintaperuste}
+import fi.oph.kouta.domain.{ExternalHakuRequest, ExternalHakukohdeRequest, ExternalKoulutusRequest, ExternalRequest, ExternalSorakuvausRequest, ExternalToteutusRequest, ExternalValintaperusteRequest, Haku, Hakukohde, Julkaisutila, Koulutus, Sorakuvaus, Arkistoitu, Toteutus, Valintaperuste}
 import fi.oph.kouta.integration.fixture.ExternalFixture
 import fi.oph.kouta.security.{Authority, ExternalSession, Role}
 import fi.oph.kouta.servlet.Authenticated

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -701,20 +701,20 @@ class ToteutusSpec extends KoutaIntegrationSpec
     toteutusBase = toteutusBase.copy(oid = Some(ToteutusOid(toteutusOid)), muokkaaja = OphUserOid,
       metadata = Some(toteutusBase.metadata.get.asInstanceOf[AmmatillinenToteutusMetadata].copy(isMuokkaajaOphVirkailija = Some(true))))
     var lastModified = get(toteutusOid, toteutusBase.copy(tila = Tallennettu))
-    update(toteutusBase.copy(tila = Julkaistu), lastModified, true, ophSession)
+    update(toteutusBase.copy(tila = Julkaistu), lastModified, expectUpdate = true, ophSession)
     lastModified = get(toteutusOid, toteutusBase.copy(tila = Julkaistu))
-    update(toteutusBase.copy(tila = Arkistoitu), lastModified, true, ophSession)
+    update(toteutusBase.copy(tila = Arkistoitu), lastModified, expectUpdate = true, ophSession)
     lastModified = get(toteutusOid, toteutusBase.copy(tila = Arkistoitu))
-    update(toteutusBase.copy(tila = Julkaistu), lastModified, true, ophSession)
+    update(toteutusBase.copy(tila = Julkaistu), lastModified, expectUpdate = true, ophSession)
     lastModified = get(toteutusOid, toteutusBase.copy(tila = Julkaistu))
-    update(toteutusBase.copy(tila = Tallennettu), lastModified, true, ophSession)
+    update(toteutusBase.copy(tila = Tallennettu), lastModified, expectUpdate = true, ophSession)
     lastModified = get(toteutusOid, toteutusBase.copy(tila = Tallennettu))
-    update(toteutusBase.copy(tila = Poistettu), lastModified, true, ophSession)
+    update(toteutusBase.copy(tila = Poistettu), lastModified, expectUpdate = true, ophSession)
 
     val arkistoituOid = Some(ToteutusOid(put(toteutus(koulutusOid).copy(tila = Arkistoitu), ophSession)))
     lastModified = get(arkistoituOid.get.s, toteutus(koulutusOid).copy(oid = arkistoituOid, tila = Arkistoitu, muokkaaja = OphUserOid,
       metadata = Some(toteutusBase.metadata.get.asInstanceOf[AmmatillinenToteutusMetadata].copy(isMuokkaajaOphVirkailija = Some(true)))))
-    update(toteutus(koulutusOid).copy(oid = arkistoituOid, tila = Julkaistu), lastModified, true, ophSession)
+    update(toteutus(koulutusOid).copy(oid = arkistoituOid, tila = Julkaistu), lastModified, expectUpdate = true, ophSession)
     get(arkistoituOid.get.s, toteutus(koulutusOid).copy(oid = arkistoituOid, tila = Julkaistu, muokkaaja = OphUserOid,
       metadata = Some(toteutusBase.metadata.get.asInstanceOf[AmmatillinenToteutusMetadata].copy(isMuokkaajaOphVirkailija = Some(true)))))
   }
@@ -743,14 +743,14 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val hakuOid = put(haku.copy(tila = Tallennettu), ophSession)
     put(hakukohde(toteutusOid, hakuOid).copy(tila = Poistettu), ophSession)
     put(hakukohde(toteutusOid, hakuOid).copy(tila = if (markAllHakukohteetDeleted) Poistettu else Tallennettu), ophSession)
-    var toteutusBase = toteutus(koulutusOid).copy(oid = Some(ToteutusOid(toteutusOid)))
+    val toteutusBase = toteutus(koulutusOid).copy(oid = Some(ToteutusOid(toteutusOid)))
     val toteutusLastModified = get(toteutusOid, toteutusBase.copy(tila = Tallennettu, muokkaaja = OphUserOid, metadata = Some(toteutusBase.metadata.get.asInstanceOf[AmmatillinenToteutusMetadata].copy(isMuokkaajaOphVirkailija = Some(true)))))
     (toteutusOid, koulutusOid, toteutusLastModified)
   }
 
   it should "pass deletion when related hakukohteet deleted" in {
     val (toteutusOid: String, koulutusOid: String, lastModified: String) = createToteutusWithHakukohteet(true)
-    update(toteutus(koulutusOid).copy(oid = Some(ToteutusOid(toteutusOid)), tila = Poistettu), lastModified, true, ophSession)
+    update(toteutus(koulutusOid).copy(oid = Some(ToteutusOid(toteutusOid)), tila = Poistettu), lastModified, expectUpdate = true, ophSession)
   }
 
   it should "fail deletion when all related hakukohteet not deleted" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -422,7 +422,6 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val lastModified = get(oid, toteutus(oid, koulutusOid))
     val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
     update(updatedToteutus, lastModified, 403, crudSessions(toteutus.organisaatioOid))
-
   }
 
   it should "deny indexer access" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -406,7 +406,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     update(thisToteutus, lastModified, 403, readSessions(toteutus.organisaatioOid))
   }
 
-  it should "allow a oph user to update from julkaistu to tallennettu" in {
+  it should "allow oph user to update from julkaistu to tallennettu" in {
     val oid = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
     val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
@@ -417,7 +417,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
         .copy(muokkaaja = OphUserOid, metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))))
   }
 
-  it should "not allow a non oph user to update from julkaistu to tallennettu" in {
+  it should "not allow non oph user to update from julkaistu to tallennettu" in {
     val oid = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
     val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -1,6 +1,5 @@
 package fi.oph.kouta.integration
 
-import cats.Show.Shown.mat
 import fi.oph.kouta.TestData.AmmToteutuksenMetatieto
 
 import java.time.LocalDateTime
@@ -9,7 +8,7 @@ import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.fixture._
 import fi.oph.kouta.mocks.{KoodistoServiceMock, LokalisointiServiceMock, MockAuditLogger}
-import fi.oph.kouta.security.Role
+import fi.oph.kouta.security.{Role, RoleEntity}
 import fi.oph.kouta.servlet.KoutaServlet
 import fi.oph.kouta.validation.{ValidationError, ammatillisetKoulutustyypit, yoKoulutustyypit}
 import fi.oph.kouta.validation.Validations._
@@ -21,7 +20,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
   with KeywordFixture with UploadFixture with LokalisointiServiceMock
   with HakukohdeFixture with HakuFixture {
 
-  override val roleEntities = Seq(Role.Toteutus, Role.Koulutus)
+  override val roleEntities: Seq[RoleEntity] = Seq(Role.Toteutus, Role.Koulutus)
 
   var koulutusOid: String = _
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -406,6 +406,25 @@ class ToteutusSpec extends KoutaIntegrationSpec
     update(thisToteutus, lastModified, 403, readSessions(toteutus.organisaatioOid))
   }
 
+  it should "allow a oph user to update from julkaistu to tallennettu" in {
+    val oid = put(toteutus(koulutusOid))
+    val lastModified = get(oid, toteutus(oid, koulutusOid))
+    val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
+    update(updatedToteutus, lastModified, expectUpdate = true, ophSession)
+    get(
+      oid,
+      toteutus(oid, koulutusOid, Tallennettu)
+        .copy(muokkaaja = OphUserOid, metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))))
+  }
+
+  it should "not allow a non oph user to update from julkaistu to tallennettu" in {
+    val oid = put(toteutus(koulutusOid))
+    val lastModified = get(oid, toteutus(oid, koulutusOid))
+    val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
+    update(updatedToteutus, lastModified, 403, crudSessions(toteutus.organisaatioOid))
+
+  }
+
   it should "deny indexer access" in {
     val oid = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ExternalFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ExternalFixture.scala
@@ -39,12 +39,18 @@ trait ExternalFixture extends KoutaIntegrationSpec with KoulutusFixture with Tot
         .asInstanceOf[YliopistoKoulutusMetadata]
         .copy(isMuokkaajaOphVirkailija = Some(isMuokkaajaOphVirkailija.getOrElse(true)))))
 
-  def createToteutus(oid: String = "", muokkaaja: Option[UserOid] = None, tila: Option[Julkaisutila] = None, isMuokkaajaOphVirkailija: Option[Boolean] = None): Toteutus =
-    toteutus.copy(koulutusOid = koulutusOidForToteutus, oid = if (oid.isEmpty) None else Some(ToteutusOid(oid)), muokkaaja = muokkaaja.getOrElse(OphUserOid), tila = tila.getOrElse(Julkaistu),
-      metadata = Some(
-      toteutus.metadata.get
-        .asInstanceOf[AmmatillinenToteutusMetadata]
-        .copy(isMuokkaajaOphVirkailija = Some(isMuokkaajaOphVirkailija.getOrElse(true)))))
+  def createToteutus(oid: String = "",
+                     muokkaaja: Option[UserOid] = None,
+                     tila: Option[Julkaisutila] = None,
+                     isMuokkaajaOphVirkailija: Option[Boolean] = None): Toteutus =
+    toteutus.copy(koulutusOid = koulutusOidForToteutus,
+                  oid = if (oid.isEmpty) None else Some(ToteutusOid(oid)),
+                  muokkaaja = muokkaaja.getOrElse(OphUserOid),
+                  tila = tila.getOrElse(Julkaistu),
+                  metadata = Some(
+                    toteutus.metadata.get
+                      .asInstanceOf[AmmatillinenToteutusMetadata]
+                      .copy(isMuokkaajaOphVirkailija = Some(isMuokkaajaOphVirkailija.getOrElse(true)))))
 
   def createHaku(oid: String = "", muokkaaja: Option[UserOid] = None, tila: Option[Julkaisutila] = None, isMuokkaajaOphVirkailija: Option[Boolean] = None): Haku =
     haku.copy(oid = if (oid.isEmpty) None else Some(HakuOid(oid)), muokkaaja = muokkaaja.getOrElse(OphUserOid), tila = tila.getOrElse(Julkaistu),

--- a/kouta-common/src/main/scala/fi/oph/kouta/domain/Julkaisutila.scala
+++ b/kouta-common/src/main/scala/fi/oph/kouta/domain/Julkaisutila.scala
@@ -5,6 +5,13 @@ sealed trait Julkaisutila extends EnumType
 object Julkaisutila extends Enum[Julkaisutila] {
   override def name: String = "julkaisutila"
   val values = List(Tallennettu, Julkaistu, Arkistoitu, Poistettu)
+
+  def isTilaUpdateAllowedOnlyForOph(oldTila: Julkaisutila, newTila: Julkaisutila): Boolean = {
+    (oldTila, newTila) match {
+      case (oldTila, newTila) if oldTila == Julkaistu && newTila == Tallennettu => true
+      case (_, _)                                                               => false
+    }
+  }
 }
 
 case object Tallennettu extends Julkaisutila { val name = "tallennettu" }


### PR DESCRIPTION
- Estetty toteutukselle tilasiirtymä julkaistu -> tallennettu (luonnos) muilla kuin pääkäyttäjän oikeuksilla
- Testi että pääkäyttäjä saa tehdä tilamuutoksen ja testi että ei pääkäyttäjä ei saa tehdä
- pientä refaktorointia

Muutoksen pihvi commitissa https://github.com/Opetushallitus/kouta-backend/commit/fe69243f0c084895bde917d5a408953493cc15b0