### PR TITLE
Korvattu truncateDatabase flywayn clean ja migrate-komennoilla

### DIFF
--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
@@ -75,7 +75,8 @@ trait KoutaIntegrationSpec
 
   override def afterAll(): Unit = {
     super.afterAll()
-    truncateDatabase()
+    db.clean()
+    db.migrate()
   }
 }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/DatabaseFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/DatabaseFixture.scala
@@ -47,46 +47,6 @@ trait DatabaseFixture {
             ALTER TABLE ${t} ENABLE TRIGGER set_last_modified_on_${t}_change;""")
       .mkString}"""))
   }
-  def truncateDatabase(): Int = {
-    db.runBlocking(sqlu"""delete from hakukohteiden_valintakokeet""")
-    db.runBlocking(sqlu"""delete from hakukohteiden_liitteet""")
-    db.runBlocking(sqlu"""delete from hakukohteiden_hakuajat""")
-    db.runBlocking(sqlu"""delete from hakukohteet""")
-    db.runBlocking(sqlu"""delete from hakujen_hakuajat""")
-    db.runBlocking(sqlu"""delete from haut""")
-    db.runBlocking(sqlu"""delete from valintaperusteiden_valintakokeet""")
-    db.runBlocking(sqlu"""delete from valintaperusteet""")
-    db.runBlocking(sqlu"""delete from toteutusten_tarjoajat""")
-    db.runBlocking(sqlu"""delete from toteutukset""")
-    db.runBlocking(sqlu"""delete from koulutusten_tarjoajat""")
-    db.runBlocking(sqlu"""delete from koulutukset""")
-
-    db.runBlocking(sqlu"""delete from hakukohteiden_valintakokeet_history""")
-    db.runBlocking(sqlu"""delete from hakukohteiden_liitteet_history""")
-    db.runBlocking(sqlu"""delete from hakukohteiden_hakuajat_history""")
-    db.runBlocking(sqlu"""delete from hakukohteet_history""")
-    db.runBlocking(sqlu"""delete from hakujen_hakuajat_history""")
-    db.runBlocking(sqlu"""delete from hakujen_valintakokeet_history""")
-    db.runBlocking(sqlu"""delete from haut_history""")
-    db.runBlocking(sqlu"""delete from valintaperusteet_history""")
-    db.runBlocking(sqlu"""delete from toteutusten_tarjoajat_history""")
-    db.runBlocking(sqlu"""delete from toteutukset_history""")
-    db.runBlocking(sqlu"""delete from koulutusten_tarjoajat_history""")
-    db.runBlocking(sqlu"""delete from koulutukset_history""")
-
-    db.runBlocking(sqlu"""delete from sorakuvaukset""")
-    db.runBlocking(sqlu"""delete from sorakuvaukset_history""")
-
-    db.runBlocking(sqlu"""delete from oppilaitosten_osat""")
-    db.runBlocking(sqlu"""delete from oppilaitosten_osat_history""")
-    db.runBlocking(sqlu"""delete from oppilaitokset""")
-    db.runBlocking(sqlu"""delete from oppilaitokset_history""")
-
-    db.runBlocking(sqlu"""delete from authorities""")
-    db.runBlocking(sqlu"""delete from sessions""")
-
-    deleteAsiasanat()
-  }
 
   def deleteAsiasanat(): Int = {
     db.runBlocking(sqlu"""delete from asiasanat""")


### PR DESCRIPTION
Vaikuttaa siltä, että truncateDatabase-kutsu ei joskus saa kunnolla tyhjennettyä kantaa, mikä aiheuttaa mielenkiintoisia ongelmia testeissä. Muutenkin varmempaa testi-suiten lopuksi pistää kanta sileäksi kunnolla.