### PR TITLE
Oy 4121 päivitetään muokkaaja entiteetin liitännäisten päivittyessä

### DIFF
--- a/kouta-backend/src/main/resources/db/migration/V108__add_toteutus_last_modified.sql
+++ b/kouta-backend/src/main/resources/db/migration/V108__add_toteutus_last_modified.sql
@@ -60,7 +60,7 @@ from toteutus_mod
 where t.oid = toteutus_mod.oid
   and t.last_modified is null;
 
--- Asetetaan koulutuksen last_modified nykyhetkeen ennen kuin toteutus itse päivittyy
+-- Asetetaan toteutuksen last_modified nykyhetkeen ennen kuin toteutus itse päivittyy
 create trigger set_toteutukset_last_modified_on_change
     before insert or update
     on toteutukset

--- a/kouta-backend/src/main/resources/db/migration/V108__add_toteutus_last_modified.sql
+++ b/kouta-backend/src/main/resources/db/migration/V108__add_toteutus_last_modified.sql
@@ -60,7 +60,7 @@ from toteutus_mod
 where t.oid = toteutus_mod.oid
   and t.last_modified is null;
 
--- Asetetaan toteutuksen last_modified nykyhetkeen ennen kuin toteutus itse päivittyy
+-- Asetetaan koulutuksen last_modified nykyhetkeen ennen kuin toteutus itse päivittyy
 create trigger set_toteutukset_last_modified_on_change
     before insert or update
     on toteutukset

--- a/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_in_modify_trigger.sql
+++ b/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_in_modify_trigger.sql
@@ -9,15 +9,20 @@ declare
     tarjoaja_muokkaaja varchar;
 begin
 if (tg_op = 'DELETE') then
-    tarjoaja_muokkaaja := old.muokkaaja;
+    RAISE NOTICE 'old: %', old;
+    update koulutukset
+    set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+    where oid = old.koulutus_oid
+      and last_modified <> now()::timestamptz;
+    return null;
 else
-    tarjoaja_muokkaaja := new.muokkaaja;
+    RAISE NOTICE 'new: %', new;
+    update koulutukset
+    set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+    where oid = new.koulutus_oid
+      and last_modified <> now()::timestamptz;
+    return null;
 end if;
-update koulutukset
-set last_modified = now()::timestamptz, muokkaaja = tarjoaja_muokkaaja
-where oid = old.koulutus_oid
-  and last_modified <> now()::timestamptz;
-return null;
 end;
 $$ language plpgsql;
 

--- a/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_in_modify_trigger.sql
+++ b/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_in_modify_trigger.sql
@@ -1,0 +1,28 @@
+-- Korvataan vanhat triggerifunktiot päivitetyillä
+drop function set_koulutukset_last_modified_from_related cascade;
+
+-- Päivitetään koulutuksen last_modified ja muokkaaja kun sen tarjoajat päivittyy, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset koulutukset-tauluun, kun useampi tarjoaja muuttuu samalla
+create or replace function set_koulutukset_last_modified_from_related() returns trigger as
+$$
+declare
+    tarjoaja_muokkaaja varchar;
+begin
+if (tg_op = 'DELETE') then
+    tarjoaja_muokkaaja := old.muokkaaja;
+else
+    tarjoaja_muokkaaja := new.muokkaaja;
+end if;
+update koulutukset
+set last_modified = now()::timestamptz, muokkaaja = tarjoaja_muokkaaja
+where oid = old.koulutus_oid
+  and last_modified <> now()::timestamptz;
+return null;
+end;
+$$ language plpgsql;
+
+create trigger set_last_modified_on_koulutusten_tarjoajat_change
+    after insert or update or delete
+                    on koulutusten_tarjoajat
+                        for each row
+                        execute procedure set_koulutukset_last_modified_from_related();

--- a/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,6 +1,3 @@
--- Korvataan vanha triggerifunktio päivitetyllä
-drop function set_koulutukset_last_modified_from_related cascade;
-
 -- Päivitetään koulutuksen last_modified ja muokkaaja kun sen tarjoajat päivittyy, mutta vain jos last_modified muuttuisi.
 -- Näin vältetään turhat muutokset koulutukset-tauluun, kun useampi tarjoaja muuttuu samalla
 create or replace function set_koulutukset_last_modified_from_related() returns trigger as
@@ -21,9 +18,3 @@ else
 end if;
 end;
 $$ language plpgsql;
-
-create trigger set_last_modified_on_koulutusten_tarjoajat_change
-    after insert or update or delete
-                    on koulutusten_tarjoajat
-                        for each row
-                        execute procedure set_koulutukset_last_modified_from_related();

--- a/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,22 +1,18 @@
--- Korvataan vanhat triggerifunktiot päivitetyillä
+-- Korvataan vanha triggerifunktio päivitetyllä
 drop function set_koulutukset_last_modified_from_related cascade;
 
 -- Päivitetään koulutuksen last_modified ja muokkaaja kun sen tarjoajat päivittyy, mutta vain jos last_modified muuttuisi.
 -- Näin vältetään turhat muutokset koulutukset-tauluun, kun useampi tarjoaja muuttuu samalla
 create or replace function set_koulutukset_last_modified_from_related() returns trigger as
 $$
-declare
-    tarjoaja_muokkaaja varchar;
 begin
 if (tg_op = 'DELETE') then
-    RAISE NOTICE 'old: %', old;
     update koulutukset
     set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
     where oid = old.koulutus_oid
       and last_modified <> now()::timestamptz;
     return null;
 else
-    RAISE NOTICE 'new: %', new;
     update koulutukset
     set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
     where oid = new.koulutus_oid

--- a/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V114__update_koulutus_muokkaaja_on_tarjoajat_change.sql
@@ -5,16 +5,15 @@ $$
 begin
 if (tg_op = 'DELETE') then
     update koulutukset
-    set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+    set last_modified = now()::timestamptz
     where oid = old.koulutus_oid
       and last_modified <> now()::timestamptz;
-    return null;
 else
     update koulutukset
     set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
     where oid = new.koulutus_oid
       and last_modified <> now()::timestamptz;
-    return null;
 end if;
+return null;
 end;
 $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,6 +1,3 @@
--- Korvataan vanhat triggerifunktiot päivitetyillä
-drop function set_toteutukset_last_modified_from_related cascade;
-
 -- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
 -- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
 create or replace function set_toteutukset_last_modified_from_related() returns trigger as
@@ -21,9 +18,3 @@ begin
     end if;
 end;
 $$ language plpgsql;
-
-create trigger set_last_modified_on_toteutusten_tarjoajat_change
-    after insert or update or delete
-    on toteutusten_tarjoajat
-    for each row
-execute procedure set_toteutukset_last_modified_from_related();

--- a/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,20 +1,20 @@
--- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
--- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
-create or replace function set_toteutukset_last_modified_from_related() returns trigger as
-$$
-begin
-    if (tg_op = 'DELETE') then
-        update toteutukset
-        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
-        where oid = old.toteutus_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    else
-        update toteutukset
-        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
-        where oid = new.toteutus_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    end if;
-end;
-$$ language plpgsql;
+-- -- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- -- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
+-- create or replace function set_toteutukset_last_modified_from_related() returns trigger as
+-- $$
+-- begin
+--     if (tg_op = 'DELETE') then
+--         update toteutukset
+--         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+--         where oid = old.toteutus_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     else
+--         update toteutukset
+--         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+--         where oid = new.toteutus_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     end if;
+-- end;
+-- $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,20 +1,20 @@
--- -- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
--- -- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
--- create or replace function set_toteutukset_last_modified_from_related() returns trigger as
--- $$
--- begin
---     if (tg_op = 'DELETE') then
---         update toteutukset
---         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
---         where oid = old.toteutus_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     else
---         update toteutukset
---         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
---         where oid = new.toteutus_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     end if;
--- end;
--- $$ language plpgsql;
+-- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
+create or replace function set_toteutukset_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update toteutukset
+        set last_modified = now()::timestamptz
+        where oid = old.toteutus_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update toteutukset
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.toteutus_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V115__update_toteutus_muokkaaja_on_tarjoajat_change.sql
@@ -1,0 +1,29 @@
+-- Korvataan vanhat triggerifunktiot päivitetyillä
+drop function set_toteutukset_last_modified_from_related cascade;
+
+-- Päivitetään toteutuksen last_modified ja muokkaaja kun sen tarjoajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset toteutukset-tauluun, kun useampi tarjoaja muuttuu samalla
+create or replace function set_toteutukset_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update toteutukset
+        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+        where oid = old.toteutus_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update toteutukset
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.toteutus_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;
+
+create trigger set_last_modified_on_toteutusten_tarjoajat_change
+    after insert or update or delete
+    on toteutusten_tarjoajat
+    for each row
+execute procedure set_toteutukset_last_modified_from_related();

--- a/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
@@ -1,20 +1,20 @@
--- Päivitetään haun last_modified ja muokkaaja kun sen hakuajat muuttuu, mutta vain jos last_modified muuttuisi.
--- Näin vältetään turhat muutokset haut-tauluun, kun useampi hakuaika muuttuu samalla
-create or replace function set_haut_last_modified_from_related() returns trigger as
-$$
-begin
-    if (tg_op = 'DELETE') then
-        update haut
-        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
-        where oid = old.haku_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    else
-        update haut
-        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
-        where oid = new.haku_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    end if;
-end;
-$$ language plpgsql;
+-- -- Päivitetään haun last_modified ja muokkaaja kun sen hakuajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- -- Näin vältetään turhat muutokset haut-tauluun, kun useampi hakuaika muuttuu samalla
+-- create or replace function set_haut_last_modified_from_related() returns trigger as
+-- $$
+-- begin
+--     if (tg_op = 'DELETE') then
+--         update haut
+--         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+--         where oid = old.haku_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     else
+--         update haut
+--         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+--         where oid = new.haku_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     end if;
+-- end;
+-- $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
@@ -1,20 +1,20 @@
--- -- Päivitetään haun last_modified ja muokkaaja kun sen hakuajat muuttuu, mutta vain jos last_modified muuttuisi.
--- -- Näin vältetään turhat muutokset haut-tauluun, kun useampi hakuaika muuttuu samalla
--- create or replace function set_haut_last_modified_from_related() returns trigger as
--- $$
--- begin
---     if (tg_op = 'DELETE') then
---         update haut
---         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
---         where oid = old.haku_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     else
---         update haut
---         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
---         where oid = new.haku_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     end if;
--- end;
--- $$ language plpgsql;
+-- Päivitetään haun last_modified ja muokkaaja kun sen hakuajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset haut-tauluun, kun useampi hakuaika muuttuu samalla
+create or replace function set_haut_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update haut
+        set last_modified = now()::timestamptz
+        where oid = old.haku_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update haut
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.haku_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
+++ b/kouta-backend/src/main/resources/db/migration/V116__update_haku_muokkaaja_on_hakuaika_change.sql
@@ -1,0 +1,20 @@
+-- Päivitetään haun last_modified ja muokkaaja kun sen hakuajat muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset haut-tauluun, kun useampi hakuaika muuttuu samalla
+create or replace function set_haut_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update haut
+        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+        where oid = old.haku_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update haut
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.haku_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
@@ -1,20 +1,20 @@
--- -- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
--- -- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
--- create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
--- $$
--- begin
---     if (tg_op = 'DELETE') then
---         update valintaperusteet
---         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
---         where id = old.valintaperuste_id
---           and last_modified <> now()::timestamptz;
---         return null;
---     else
---         update valintaperusteet
---         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
---         where id = new.valintaperuste_id
---           and last_modified <> now()::timestamptz;
---         return null;
---     end if;
--- end;
--- $$ language plpgsql;
+-- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
+create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update valintaperusteet
+        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+        where id = old.valintaperuste_id
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update valintaperusteet
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where id = new.valintaperuste_id
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
@@ -1,20 +1,20 @@
--- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
--- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
-create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
-$$
-begin
-    if (tg_op = 'DELETE') then
-        update valintaperusteet
-        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
-        where id = old.valintaperuste_id
-          and last_modified <> now()::timestamptz;
-        return null;
-    else
-        update valintaperusteet
-        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
-        where id = new.valintaperuste_id
-          and last_modified <> now()::timestamptz;
-        return null;
-    end if;
-end;
-$$ language plpgsql;
+-- -- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
+-- -- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
+-- create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
+-- $$
+-- begin
+--     if (tg_op = 'DELETE') then
+--         update valintaperusteet
+--         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+--         where id = old.valintaperuste_id
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     else
+--         update valintaperusteet
+--         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+--         where id = new.valintaperuste_id
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     end if;
+-- end;
+-- $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
@@ -1,20 +1,20 @@
--- -- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
--- -- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
--- create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
--- $$
--- begin
---     if (tg_op = 'DELETE') then
---         update valintaperusteet
---         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
---         where id = old.valintaperuste_id
---           and last_modified <> now()::timestamptz;
---         return null;
---     else
---         update valintaperusteet
---         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
---         where id = new.valintaperuste_id
---           and last_modified <> now()::timestamptz;
---         return null;
---     end if;
--- end;
--- $$ language plpgsql;
+-- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
+create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update valintaperusteet
+        set last_modified = now()::timestamptz
+        where id = old.valintaperuste_id
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update valintaperusteet
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where id = new.valintaperuste_id
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V117__update_valintaperuste_muokkaaja_on_valintakoe_update.sql
@@ -1,0 +1,20 @@
+-- -- Päivitetään valintaperusteen last_modified ja muokkaaja kun sen valintakokeet muuttuu, mutta vain jos last_modified muuttuisi.
+-- -- Näin vältetään turhat muutokset valintaperusteet-tauluun, kun useampi valintakoe muuttuu samalla
+-- create or replace function set_valintaperusteet_last_modified_from_related() returns trigger as
+-- $$
+-- begin
+--     if (tg_op = 'DELETE') then
+--         update valintaperusteet
+--         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+--         where id = old.valintaperuste_id
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     else
+--         update valintaperusteet
+--         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+--         where id = new.valintaperuste_id
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     end if;
+-- end;
+-- $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
@@ -1,20 +1,20 @@
--- Päivitetään hakukohteen last_modified ja muokkaaja kun sen hakuajat, valintakokeet tai liitteet muuttuu, mutta vain jos last_modified muuttuisi.
--- Näin vältetään turhat muutokset hakukohteet-tauluun, kun useampi hakuaika, valintakoe tai liite muuttuu samalla
-create or replace function set_hakukohteet_last_modified_from_related() returns trigger as
-$$
-begin
-    if (tg_op = 'DELETE') then
-        update hakukohteet
-        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
-        where oid = old.hakukohde_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    else
-        update hakukohteet
-        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
-        where oid = new.hakukohde_oid
-          and last_modified <> now()::timestamptz;
-        return null;
-    end if;
-end;
-$$ language plpgsql;
+-- -- Päivitetään hakukohteen last_modified ja muokkaaja kun sen hakuajat, valintakokeet tai liitteet muuttuu, mutta vain jos last_modified muuttuisi.
+-- -- Näin vältetään turhat muutokset hakukohteet-tauluun, kun useampi hakuaika, valintakoe tai liite muuttuu samalla
+-- create or replace function set_hakukohteet_last_modified_from_related() returns trigger as
+-- $$
+-- begin
+--     if (tg_op = 'DELETE') then
+--         update hakukohteet
+--         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+--         where oid = old.hakukohde_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     else
+--         update hakukohteet
+--         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+--         where oid = new.hakukohde_oid
+--           and last_modified <> now()::timestamptz;
+--         return null;
+--     end if;
+-- end;
+-- $$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
@@ -1,0 +1,20 @@
+-- Päivitetään hakukohteen last_modified ja muokkaaja kun sen hakuajat, valintakokeet tai liitteet muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset hakukohteet-tauluun, kun useampi hakuaika, valintakoe tai liite muuttuu samalla
+create or replace function set_hakukohteet_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update hakukohteet
+        set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
+        where oid = old.hakukohde_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update hakukohteet
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.hakukohde_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
+++ b/kouta-backend/src/main/resources/db/migration/V118__update_hakukohde_muokkaaja_on_related_update.sql
@@ -1,20 +1,20 @@
--- -- Päivitetään hakukohteen last_modified ja muokkaaja kun sen hakuajat, valintakokeet tai liitteet muuttuu, mutta vain jos last_modified muuttuisi.
--- -- Näin vältetään turhat muutokset hakukohteet-tauluun, kun useampi hakuaika, valintakoe tai liite muuttuu samalla
--- create or replace function set_hakukohteet_last_modified_from_related() returns trigger as
--- $$
--- begin
---     if (tg_op = 'DELETE') then
---         update hakukohteet
---         set last_modified = now()::timestamptz, muokkaaja = old.muokkaaja
---         where oid = old.hakukohde_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     else
---         update hakukohteet
---         set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
---         where oid = new.hakukohde_oid
---           and last_modified <> now()::timestamptz;
---         return null;
---     end if;
--- end;
--- $$ language plpgsql;
+-- Päivitetään hakukohteen last_modified ja muokkaaja kun sen hakuajat, valintakokeet tai liitteet muuttuu, mutta vain jos last_modified muuttuisi.
+-- Näin vältetään turhat muutokset hakukohteet-tauluun, kun useampi hakuaika, valintakoe tai liite muuttuu samalla
+create or replace function set_hakukohteet_last_modified_from_related() returns trigger as
+$$
+begin
+    if (tg_op = 'DELETE') then
+        update hakukohteet
+        set last_modified = now()::timestamptz
+        where oid = old.hakukohde_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    else
+        update hakukohteet
+        set last_modified = now()::timestamptz, muokkaaja = new.muokkaaja
+        where oid = new.hakukohde_oid
+          and last_modified <> now()::timestamptz;
+        return null;
+    end if;
+end;
+$$ language plpgsql;

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/hakuDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/hakuDAO.scala
@@ -150,6 +150,7 @@ sealed trait HakuSQL extends HakuExtractors with HakuModificationSQL with SQLHel
   }
 
   def updateHaku(haku: Haku): DBIO[Int] = {
+    // note! This updates always when muokkaaja changes, even without other changes
     sqlu"""update haut set
               external_id = ${haku.externalId},
               hakutapa_koodi_uri = ${haku.hakutapaKoodiUri},

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/hakukohdeDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/hakukohdeDAO.scala
@@ -301,7 +301,6 @@ sealed trait HakukohdeSQL extends SQLHelpers with HakukohdeModificationSQL with 
   }
 
   def updateHakukohteenMuokkaaja(hakukohdeOid: Option[HakukohdeOid], muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"Päivitetään hakukohteen muokkaaja")
     sqlu"""update hakukohteet set
               muokkaaja = ${muokkaaja}
           where oid = ${hakukohdeOid} and muokkaaja is distinct from ${muokkaaja}"""

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/koulutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/koulutusDAO.scala
@@ -18,9 +18,17 @@ trait KoulutusDAO extends EntityModificationDAO[KoulutusOid] {
 
   def get(oid: KoulutusOid, tilaFilter: TilaFilter): Option[(Koulutus, Instant)]
   def get(oid: KoulutusOid): Option[Koulutus]
-  def listAllowedByOrganisaatiot(organisaatioOids: Seq[OrganisaatioOid], koulutustyypit: Seq[Koulutustyyppi], tilaFilter: TilaFilter): Seq[KoulutusListItem]
-  def listAllowedByOrganisaatiotAndKoulutustyyppi(organisaatioOids: Seq[OrganisaatioOid], koulutustyyppi: Koulutustyyppi, tilaFilter: TilaFilter): Seq[KoulutusListItem]
-  def listByHakuOid(hakuOid: HakuOid) :Seq[KoulutusListItem]
+  def listAllowedByOrganisaatiot(
+      organisaatioOids: Seq[OrganisaatioOid],
+      koulutustyypit: Seq[Koulutustyyppi],
+      tilaFilter: TilaFilter
+  ): Seq[KoulutusListItem]
+  def listAllowedByOrganisaatiotAndKoulutustyyppi(
+      organisaatioOids: Seq[OrganisaatioOid],
+      koulutustyyppi: Koulutustyyppi,
+      tilaFilter: TilaFilter
+  ): Seq[KoulutusListItem]
+  def listByHakuOid(hakuOid: HakuOid): Seq[KoulutusListItem]
   def getJulkaistutByTarjoajaOids(organisaatioOids: Seq[OrganisaatioOid]): Seq[Koulutus]
   def listBySorakuvausId(sorakuvausId: UUID, tilaFilter: TilaFilter): Seq[String]
   def listTarjoajaOids(oid: KoulutusOid): Seq[OrganisaatioOid]
@@ -36,12 +44,14 @@ object KoulutusDAO extends KoulutusDAO with KoulutusSQL {
     } yield koulutus.withOid(oid).withModified(m.get)
 
   override def get(oid: KoulutusOid, tilaFilter: TilaFilter): Option[(Koulutus, Instant)] = {
-    KoutaDatabase.runBlockingTransactionally(
-      for {
-        k <- selectKoulutus(oid, tilaFilter).as[Koulutus].headOption
-        t <- selectKoulutuksenTarjoajat(oid).as[Tarjoaja]
-      } yield (k, t)
-    ).get match {
+    KoutaDatabase
+      .runBlockingTransactionally(
+        for {
+          k <- selectKoulutus(oid, tilaFilter).as[Koulutus].headOption
+          t <- selectKoulutuksenTarjoajat(oid).as[Tarjoaja]
+        } yield (k, t)
+      )
+      .get match {
       case (Some(k), t) =>
         Some((k.copy(tarjoajat = t.map(_.tarjoajaOid).toList), modifiedToInstant(k.modified.get)))
       case _ => None
@@ -49,7 +59,9 @@ object KoulutusDAO extends KoulutusDAO with KoulutusSQL {
   }
 
   override def get(oid: KoulutusOid): Option[Koulutus] = {
-    KoutaDatabase.runBlockingTransactionally(selectKoulutus(oid, TilaFilter.onlyOlemassaolevat()).as[Koulutus].headOption).get
+    KoutaDatabase
+      .runBlockingTransactionally(selectKoulutus(oid, TilaFilter.onlyOlemassaolevat()).as[Koulutus].headOption)
+      .get
   }
 
   override def getUpdateActions(koulutus: Koulutus): DBIO[Option[Koulutus]] =
@@ -82,44 +94,65 @@ object KoulutusDAO extends KoulutusDAO with KoulutusSQL {
   }
 
   private def listWithTarjoajat(selectListItems: => DBIO[Seq[KoulutusListItem]]): Seq[KoulutusListItem] =
-    KoutaDatabase.runBlockingTransactionally(
-      for {
+    KoutaDatabase
+      .runBlockingTransactionally(for {
         koulutukset <- selectListItems
         tarjoajat   <- selectKoulutustenTarjoajat(koulutukset.map(_.oid).toList).as[Tarjoaja]
-      } yield (koulutukset, tarjoajat) ).map {
-      case (toteutukset, tarjoajat) => {
-        toteutukset.map(t =>
-          t.copy(tarjoajat = tarjoajat.filter(_.oid.toString == t.oid.toString).map(_.tarjoajaOid).toList))
+      } yield (koulutukset, tarjoajat))
+      .map {
+        case (toteutukset, tarjoajat) => {
+          toteutukset.map(t =>
+            t.copy(tarjoajat = tarjoajat.filter(_.oid.toString == t.oid.toString).map(_.tarjoajaOid).toList)
+          )
+        }
       }
-    }.get
+      .get
 
-  override def listAllowedByOrganisaatiot(organisaatioOids: Seq[OrganisaatioOid], koulutustyypit: Seq[Koulutustyyppi], tilaFilter: TilaFilter): Seq[KoulutusListItem] =
+  override def listAllowedByOrganisaatiot(
+      organisaatioOids: Seq[OrganisaatioOid],
+      koulutustyypit: Seq[Koulutustyyppi],
+      tilaFilter: TilaFilter
+  ): Seq[KoulutusListItem] =
     (organisaatioOids, koulutustyypit) match {
       case (Nil, _) => Seq()
-      case (_, Nil) => listWithTarjoajat { selectByCreatorAndNotOph(organisaatioOids, tilaFilter) } //OPH:lla pitäisi olla aina kaikki koulutustyypit
-      case _        => listWithTarjoajat { selectByCreatorOrJulkinenForKoulutustyyppi(organisaatioOids, koulutustyypit, tilaFilter) }
+      case (_, Nil) =>
+        listWithTarjoajat {
+          selectByCreatorAndNotOph(organisaatioOids, tilaFilter)
+        } //OPH:lla pitäisi olla aina kaikki koulutustyypit
+      case _ =>
+        listWithTarjoajat { selectByCreatorOrJulkinenForKoulutustyyppi(organisaatioOids, koulutustyypit, tilaFilter) }
     }
 
-  override def listAllowedByOrganisaatiotAndKoulutustyyppi(organisaatioOids: Seq[OrganisaatioOid], koulutustyyppi: Koulutustyyppi, tilaFilter: TilaFilter): Seq[KoulutusListItem] =
+  override def listAllowedByOrganisaatiotAndKoulutustyyppi(
+      organisaatioOids: Seq[OrganisaatioOid],
+      koulutustyyppi: Koulutustyyppi,
+      tilaFilter: TilaFilter
+  ): Seq[KoulutusListItem] =
     (organisaatioOids, koulutustyyppi) match {
       case (Nil, _) => Seq()
-      case _        => listWithTarjoajat { selectByCreatorOrJulkinenForSpecificKoulutustyyppi(organisaatioOids, koulutustyyppi, tilaFilter) }
+      case _ =>
+        listWithTarjoajat {
+          selectByCreatorOrJulkinenForSpecificKoulutustyyppi(organisaatioOids, koulutustyyppi, tilaFilter)
+        }
     }
 
-  override def listByHakuOid(hakuOid: HakuOid) :Seq[KoulutusListItem] =
+  override def listByHakuOid(hakuOid: HakuOid): Seq[KoulutusListItem] =
     listWithTarjoajat(selectByHakuOid(hakuOid))
 
   override def getJulkaistutByTarjoajaOids(organisaatioOids: Seq[OrganisaatioOid]): Seq[Koulutus] = {
-    KoutaDatabase.runBlockingTransactionally(
-      for {
+    KoutaDatabase
+      .runBlockingTransactionally(for {
         koulutukset <- findJulkaistutKoulutuksetByTarjoajat(organisaatioOids).as[Koulutus]
         tarjoajat   <- selectKoulutustenTarjoajat(koulutukset.map(_.oid.get).toList).as[Tarjoaja]
-      } yield (koulutukset, tarjoajat)).map {
-      case (koulutukset, tarjoajat) => {
-        koulutukset.map(t =>
-          t.copy(tarjoajat = tarjoajat.filter(_.oid.toString == t.oid.get.toString).map(_.tarjoajaOid).toList))
+      } yield (koulutukset, tarjoajat))
+      .map {
+        case (koulutukset, tarjoajat) => {
+          koulutukset.map(t =>
+            t.copy(tarjoajat = tarjoajat.filter(_.oid.toString == t.oid.get.toString).map(_.tarjoajaOid).toList)
+          )
+        }
       }
-    }.get
+      .get
   }
 
   override def listBySorakuvausId(sorakuvausId: UUID, tilaFilter: TilaFilter): Seq[String] = {
@@ -185,8 +218,9 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
   }
 
   def insertKoulutuksenTarjoajat(koulutus: Koulutus): DBIO[Int] = {
-    val inserts = koulutus.tarjoajat.map(t =>
-      sqlu"""insert into koulutusten_tarjoajat (koulutus_oid, tarjoaja_oid, muokkaaja)
+    logger.info(s"INSERT TARJOAJAT, MUOKKAAJA: " + koulutus.muokkaaja)
+    val inserts =
+      koulutus.tarjoajat.map(t => sqlu"""insert into koulutusten_tarjoajat (koulutus_oid, tarjoaja_oid, muokkaaja)
              values (${koulutus.oid}, $t, ${koulutus.muokkaaja})""")
     DBIOHelpers.sumIntDBIOs(inserts)
   }
@@ -244,10 +278,13 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
   }
 
   def selectKoulutustenTarjoajat(oids: List[KoulutusOid]) = {
-    sql"""select koulutus_oid, tarjoaja_oid from koulutusten_tarjoajat where koulutus_oid in (#${createOidInParams(oids)})"""
+    sql"""select koulutus_oid, tarjoaja_oid from koulutusten_tarjoajat where koulutus_oid in (#${createOidInParams(
+      oids
+    )})"""
   }
 
   def updateKoulutus(koulutus: Koulutus): DBIO[Int] = {
+    logger.info(s"update koulutus, muokkaaja: " + koulutus.muokkaaja)
     sqlu"""update koulutukset set
               external_id = ${koulutus.externalId},
               johtaa_tutkintoon = ${koulutus.johtaaTutkintoon},
@@ -281,20 +318,24 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
             or organisaatio_oid is distinct from ${koulutus.organisaatioOid})"""
   }
 
-  def insertTarjoaja(oid: Option[KoulutusOid], tarjoaja: OrganisaatioOid, muokkaaja: UserOid ): DBIO[Int] = {
+  def insertTarjoaja(oid: Option[KoulutusOid], tarjoaja: OrganisaatioOid, muokkaaja: UserOid): DBIO[Int] = {
+    logger.info(s"insert TARJOAJA, muokkaaja: " + muokkaaja)
     sqlu"""insert into koulutusten_tarjoajat (koulutus_oid, tarjoaja_oid, muokkaaja)
              values ($oid, $tarjoaja, $muokkaaja)
              on conflict on constraint koulutusten_tarjoajat_pkey do nothing"""
   }
 
   def deleteTarjoajat(oid: Option[KoulutusOid], exclude: List[OrganisaatioOid]): DBIO[Int] = {
+    logger.info(s"DELETE TARJOAJAT org rajauksella")
     sqlu"""delete from koulutusten_tarjoajat
           where koulutus_oid = $oid
            and tarjoaja_oid not in (#${createOidInParams(exclude)})"""
   }
 
-  def deleteTarjoajat(oid: Option[KoulutusOid]): DBIO[Int] =
+  def deleteTarjoajat(oid: Option[KoulutusOid]): DBIO[Int] = {
+    logger.info(s"DELETE TARJOAJAT")
     sqlu"""delete from koulutusten_tarjoajat where koulutus_oid = $oid"""
+  }
 
   val selectKoulutusListSql =
     s"""select distinct k.oid, k.nimi, k.tila, k.organisaatio_oid, k.muokkaaja, k.last_modified from koulutukset k"""
@@ -319,13 +360,15 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
             -- 1. koulutukset, jotka omistaa jokin annetuista organisaatioista, mutta OPH:n omistamat vain, jos koulutustyyppi täsmää.
             -- TODO: Mahdollisesti, jos OPH:n omistama, pitäisi katsoa, että se on lisäksi julkinen ja mätsää oppilaitostyyppeihin
             ((k.organisaatio_oid in (#${createOidInParams(organisaatioOids)})
-                and (k.organisaatio_oid <> ${RootOrganisaatioOid} or k.tyyppi in (#${createKoulutustyypitInParams(koulutustyypit)})))
+                and (k.organisaatio_oid <> ${RootOrganisaatioOid} or k.tyyppi in (#${createKoulutustyypitInParams(
+      koulutustyypit
+    )})))
             -- 2. koulutustyyppeihin täsmäävät koulutukset, jotka ovat julkisia
             or (k.julkinen = ${true} and k.tyyppi in (#${createKoulutustyypitInParams(koulutustyypit)}))
             -- 3. jotka ovat avointa korkeakoulutusta ja tarjoajista (järjestäjistä) löytyy annettuja organisaatioita
             or (k.metadata ->> 'isAvoinKorkeakoulutus' = 'true'
                 and ta.tarjoaja_oid in (#${createOidInParams(organisaatioOids)})))
-    #${tilaConditions(tilaFilter, glueWord="and")}
+    #${tilaConditions(tilaFilter, glueWord = "and")}
 """.as[KoulutusListItem]
   }
 

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/koulutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/koulutusDAO.scala
@@ -218,7 +218,6 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
   }
 
   def insertKoulutuksenTarjoajat(koulutus: Koulutus): DBIO[Int] = {
-    logger.info(s"INSERT TARJOAJAT, MUOKKAAJA: " + koulutus.muokkaaja)
     val inserts =
       koulutus.tarjoajat.map(t => sqlu"""insert into koulutusten_tarjoajat (koulutus_oid, tarjoaja_oid, muokkaaja)
              values (${koulutus.oid}, $t, ${koulutus.muokkaaja})""")
@@ -284,7 +283,6 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
   }
 
   def updateKoulutus(koulutus: Koulutus): DBIO[Int] = {
-    logger.info(s"update koulutus, muokkaaja: " + koulutus.muokkaaja)
     sqlu"""update koulutukset set
               external_id = ${koulutus.externalId},
               johtaa_tutkintoon = ${koulutus.johtaaTutkintoon},
@@ -319,21 +317,18 @@ sealed trait KoulutusSQL extends KoulutusExtractors with KoulutusModificationSQL
   }
 
   def insertTarjoaja(oid: Option[KoulutusOid], tarjoaja: OrganisaatioOid, muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"insert TARJOAJA, muokkaaja: " + muokkaaja)
     sqlu"""insert into koulutusten_tarjoajat (koulutus_oid, tarjoaja_oid, muokkaaja)
              values ($oid, $tarjoaja, $muokkaaja)
              on conflict on constraint koulutusten_tarjoajat_pkey do nothing"""
   }
 
   def deleteTarjoajat(oid: Option[KoulutusOid], exclude: List[OrganisaatioOid]): DBIO[Int] = {
-    logger.info(s"DELETE TARJOAJAT org rajauksella")
     sqlu"""delete from koulutusten_tarjoajat
           where koulutus_oid = $oid
            and tarjoaja_oid not in (#${createOidInParams(exclude)})"""
   }
 
   def deleteTarjoajat(oid: Option[KoulutusOid]): DBIO[Int] = {
-    logger.info(s"DELETE TARJOAJAT")
     sqlu"""delete from koulutusten_tarjoajat where koulutus_oid = $oid"""
   }
 

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
@@ -2,6 +2,7 @@ package fi.oph.kouta.repository
 
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.domain._
+import fi.oph.kouta.repository.ToteutusDAO.logger
 import fi.oph.kouta.service.ToteutusService
 import fi.oph.kouta.util.MiscUtils.optionWhen
 import fi.oph.kouta.util.TimeUtils.modifiedToInstant
@@ -64,12 +65,13 @@ object ToteutusDAO extends ToteutusDAO with ToteutusSQL {
   }
 
   def updateToteutuksenTarjoajat(toteutus: Toteutus): DBIO[Int] = {
+    logger.info(s"Update tarjoajat $toteutus")
     val (oid, tarjoajat, muokkaaja) = (toteutus.oid, toteutus.tarjoajat, toteutus.muokkaaja)
     if (tarjoajat.nonEmpty) {
-      val actions = tarjoajat.map(insertTarjoaja(oid, _, muokkaaja)) :+ deleteTarjoajat(oid, tarjoajat)
+      val actions = tarjoajat.map(insertTarjoaja(oid, _, muokkaaja)) :+ deleteTarjoajat(oid, tarjoajat) :+ updateToteutuksenMuokkaaja(oid, muokkaaja)
       DBIOHelpers.sumIntDBIOs(actions)
     } else {
-      deleteTarjoajat(oid)
+      DBIOHelpers.sumIntDBIOs(Seq(updateToteutuksenMuokkaaja(oid, muokkaaja), deleteTarjoajat(oid)))
     }
   }
 
@@ -291,20 +293,30 @@ sealed trait ToteutusSQL extends ToteutusExtractors with ToteutusModificationSQL
             or sorakuvaus_id is distinct from ${toteutus.sorakuvausId.map(_.toString)}::uuid)"""
   }
 
+  def updateToteutuksenMuokkaaja(toteutusOid: Option[ToteutusOid], muokkaaja: UserOid): DBIO[Int] = {
+    logger.info(s"update toteutuksen muokkaaja $muokkaaja")
+    sqlu"""update toteutukset set
+              muokkaaja = ${muokkaaja}
+            where oid = ${toteutusOid}"""
+  }
   def insertTarjoaja(oid: Option[ToteutusOid], tarjoaja: OrganisaatioOid, muokkaaja: UserOid): DBIO[Int] = {
+    logger.info(s"insert tarjoaja $tarjoaja")
     sqlu"""insert into toteutusten_tarjoajat (toteutus_oid, tarjoaja_oid, muokkaaja)
              values ($oid, $tarjoaja, $muokkaaja)
              on conflict on constraint toteutusten_tarjoajat_pkey do nothing"""
   }
 
   def deleteTarjoajat(oid: Option[ToteutusOid], exclude: List[OrganisaatioOid]): DBIO[Int] = {
+    logger.info(s"dellataan kaikki tarjoajat paitsi  $exclude" )
     sqlu"""delete from toteutusten_tarjoajat
            where toteutus_oid = $oid and tarjoaja_oid not in (#${createOidInParams(exclude)})"""
   }
 
-  def deleteTarjoajat(oid: Option[ToteutusOid]): DBIO[Int] =
+  def deleteTarjoajat(oid: Option[ToteutusOid]): DBIO[Int] = {
+    logger.info(s"dellataan tarjoajat")
     sqlu"""delete from toteutusten_tarjoajat
            where toteutus_oid = $oid"""
+  }
 
   val selectToteutusListSql =
     """select distinct t.oid, t.koulutus_oid, t.nimi, t.tila, t.organisaatio_oid, t.muokkaaja, t.last_modified, t.metadata, k.metadata, k.koulutukset_koodi_uri

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
@@ -65,7 +65,6 @@ object ToteutusDAO extends ToteutusDAO with ToteutusSQL {
   }
 
   def updateToteutuksenTarjoajat(toteutus: Toteutus): DBIO[Int] = {
-    logger.info(s"Update tarjoajat $toteutus")
     val (oid, tarjoajat, muokkaaja) = (toteutus.oid, toteutus.tarjoajat, toteutus.muokkaaja)
     if (tarjoajat.nonEmpty) {
       val actions = tarjoajat.map(insertTarjoaja(oid, _, muokkaaja)) :+ deleteTarjoajat(oid, tarjoajat) :+ updateToteutuksenMuokkaaja(oid, muokkaaja)
@@ -294,26 +293,22 @@ sealed trait ToteutusSQL extends ToteutusExtractors with ToteutusModificationSQL
   }
 
   def updateToteutuksenMuokkaaja(toteutusOid: Option[ToteutusOid], muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"update toteutuksen muokkaaja $muokkaaja")
     sqlu"""update toteutukset set
               muokkaaja = ${muokkaaja}
             where oid = ${toteutusOid}"""
   }
   def insertTarjoaja(oid: Option[ToteutusOid], tarjoaja: OrganisaatioOid, muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"insert tarjoaja $tarjoaja")
     sqlu"""insert into toteutusten_tarjoajat (toteutus_oid, tarjoaja_oid, muokkaaja)
              values ($oid, $tarjoaja, $muokkaaja)
              on conflict on constraint toteutusten_tarjoajat_pkey do nothing"""
   }
 
   def deleteTarjoajat(oid: Option[ToteutusOid], exclude: List[OrganisaatioOid]): DBIO[Int] = {
-    logger.info(s"dellataan kaikki tarjoajat paitsi  $exclude" )
     sqlu"""delete from toteutusten_tarjoajat
            where toteutus_oid = $oid and tarjoaja_oid not in (#${createOidInParams(exclude)})"""
   }
 
   def deleteTarjoajat(oid: Option[ToteutusOid]): DBIO[Int] = {
-    logger.info(s"dellataan tarjoajat")
     sqlu"""delete from toteutusten_tarjoajat
            where toteutus_oid = $oid"""
   }

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
@@ -66,11 +66,21 @@ object ToteutusDAO extends ToteutusDAO with ToteutusSQL {
 
   def updateToteutuksenTarjoajat(toteutus: Toteutus): DBIO[Int] = {
     val (oid, tarjoajat, muokkaaja) = (toteutus.oid, toteutus.tarjoajat, toteutus.muokkaaja)
-    if (tarjoajat.nonEmpty) {
-      val actions = tarjoajat.map(insertTarjoaja(oid, _, muokkaaja)) :+ deleteTarjoajat(oid, tarjoajat) :+ updateToteutuksenMuokkaaja(oid, muokkaaja)
-      DBIOHelpers.sumIntDBIOs(actions)
-    } else {
-      DBIOHelpers.sumIntDBIOs(Seq(updateToteutuksenMuokkaaja(oid, muokkaaja), deleteTarjoajat(oid)))
+    val oldTarjoajat = KoutaDatabase.runBlockingTransactionally(
+      for {
+        t <- selectToteutuksenTarjoajat(oid.get).as[Tarjoaja]
+      } yield t.toList)
+    val inserted = tarjoajat.filterNot(oid => oldTarjoajat.get.map(_.tarjoajaOid).contains(oid))
+    val deleted = oldTarjoajat.get.filterNot(t => tarjoajat.contains(t.tarjoajaOid))
+
+    (inserted.nonEmpty, deleted.nonEmpty) match {
+      case (true, any) =>
+        val actions = inserted.map(insertTarjoaja(oid, _, muokkaaja)) :+ deleteTarjoajatByOids(oid, deleted.map(_.tarjoajaOid))
+        DBIOHelpers.sumIntDBIOs(actions)
+      case (false, true)  =>
+        // if changes were deletions, database trigger won't update muokkaaja of toteutus
+        DBIOHelpers.sumIntDBIOs(Seq(updateToteutuksenMuokkaaja(oid, muokkaaja), deleteTarjoajatByOids(oid, deleted.map(_.tarjoajaOid))))
+      case _ => DBIO.successful(0)
     }
   }
 
@@ -293,6 +303,7 @@ sealed trait ToteutusSQL extends ToteutusExtractors with ToteutusModificationSQL
   }
 
   def updateToteutuksenMuokkaaja(toteutusOid: Option[ToteutusOid], muokkaaja: UserOid): DBIO[Int] = {
+    logger.info(s"update toteutuksen muokkaaja")
     sqlu"""update toteutukset set
               muokkaaja = ${muokkaaja}
             where oid = ${toteutusOid}"""
@@ -306,6 +317,11 @@ sealed trait ToteutusSQL extends ToteutusExtractors with ToteutusModificationSQL
   def deleteTarjoajat(oid: Option[ToteutusOid], exclude: List[OrganisaatioOid]): DBIO[Int] = {
     sqlu"""delete from toteutusten_tarjoajat
            where toteutus_oid = $oid and tarjoaja_oid not in (#${createOidInParams(exclude)})"""
+  }
+
+  def deleteTarjoajatByOids(oid: Option[ToteutusOid], deletedOids: List[OrganisaatioOid]): DBIO[Int] = {
+    sqlu"""delete from toteutusten_tarjoajat
+           where toteutus_oid = $oid and tarjoaja_oid in (#${createOidInParams(deletedOids)})"""
   }
 
   def deleteTarjoajat(oid: Option[ToteutusOid]): DBIO[Int] = {

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/toteutusDAO.scala
@@ -2,7 +2,6 @@ package fi.oph.kouta.repository
 
 import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.domain._
-import fi.oph.kouta.repository.ToteutusDAO.logger
 import fi.oph.kouta.service.ToteutusService
 import fi.oph.kouta.util.MiscUtils.optionWhen
 import fi.oph.kouta.util.TimeUtils.modifiedToInstant
@@ -303,7 +302,6 @@ sealed trait ToteutusSQL extends ToteutusExtractors with ToteutusModificationSQL
   }
 
   def updateToteutuksenMuokkaaja(toteutusOid: Option[ToteutusOid], muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"update toteutuksen muokkaaja")
     sqlu"""update toteutukset set
               muokkaaja = ${muokkaaja}
             where oid = ${toteutusOid}"""

--- a/kouta-backend/src/main/scala/fi/oph/kouta/repository/valintaperusteDAO.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/repository/valintaperusteDAO.scala
@@ -199,7 +199,6 @@ sealed trait ValintaperusteSQL extends ValintaperusteExtractors with Valintaperu
   }
 
   def updateValintaperusteenMuokkaaja(valintaperusteId: Option[UUID], muokkaaja: UserOid): DBIO[Int] = {
-    logger.info(s"update valintaperusteen muokkaaja: ${muokkaaja}")
     sqlu"""update valintaperusteet set
             muokkaaja = ${muokkaaja}
            where id = ${valintaperusteId.map(_.toString)}::uuid"""

--- a/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/TestData.scala
@@ -19,11 +19,15 @@ object TestData {
   val endTime1: LocalDateTime =
     LocalDate.now().plusDays(1).atTime(LocalTime.parse("09:58")).truncatedTo(ChronoUnit.MINUTES)
   val muokkaajanNimi: String = "Testi Muokkaaja"
-  val defaultKuvaus = Map(Fi -> "kuvaus", Sv -> "kuvaus sv")
+  val defaultKuvaus          = Map(Fi -> "kuvaus", Sv -> "kuvaus sv")
 
   def kieliMap(text: String): Kielistetty = Map(Fi -> s"$text fi", Sv -> s"$text sv")
 
   def getInvalidHakuajat = List(Ajanjakso(TestData.inFuture(9000), Some(TestData.inFuture(3000))))
+
+  def getHakuajatWeeksInFuture(startWeeks: Int, endWeeks: Int) = List(
+    Ajanjakso(alkaa = inFuture().plusWeeks(startWeeks), paattyy = Some(inFuture().plusWeeks(endWeeks)))
+  )
 
   val Osoite1: Osoite =
     Osoite(osoite = Map(Fi -> "Kivatie 1", Sv -> "kivavägen 1"), postinumeroKoodiUri = Some("posti_04230#2"))
@@ -555,7 +559,7 @@ object TestData {
     linkkiEPerusteisiin = Map(Fi -> "http://testilinkki.fi", Sv -> "http://testlink.sv"),
     isMuokkaajaOphVirkailija = Some(true),
     opintojenLaajuusNumero = Some(20),
-    opintojenLaajuusyksikkoKoodiUri = Some("opintojenlaajuusyksikko_6#1"),
+    opintojenLaajuusyksikkoKoodiUri = Some("opintojenlaajuusyksikko_6#1")
   )
 
   val TelmaKoulutus: Koulutus = Koulutus(
@@ -1204,20 +1208,22 @@ object TestData {
     hasJotpaRahoitus = Some(false)
   )
 
-  val ErikoistumiskoulutusToteutuksenMetatieto: ErikoistumiskoulutusToteutusMetadata = ErikoistumiskoulutusToteutusMetadata(
-    kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
-    opetus = Some(ToteutuksenOpetus),
-    asiasanat = List(Keyword(Fi, "robotiikka"), Keyword(Fi, "robottiautomatiikka")),
-    hakutermi = Some(Hakeutuminen),
-    hakulomaketyyppi = Some(MuuHakulomake),
-    hakulomakeLinkki = Map(Fi -> "http://www.linkki.fi", Sv -> "http://www.linkki.se"),
-    lisatietoaHakeutumisesta = Map(Fi -> "Lisätieto", Sv -> "Lisätieto sv"),
-    lisatietoaValintaperusteista = Map(Fi -> "Lisätieto", Sv -> "Lisätieto sv"),
-    hakuaika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture().plusYears(200)))),
-    yhteyshenkilot = Seq(Yhteystieto1),
-    aloituspaikat = None,
-    isMuokkaajaOphVirkailija = Some(false),
-    hasJotpaRahoitus = Some(false))
+  val ErikoistumiskoulutusToteutuksenMetatieto: ErikoistumiskoulutusToteutusMetadata =
+    ErikoistumiskoulutusToteutusMetadata(
+      kuvaus = Map(Fi -> "Kuvaus", Sv -> "Kuvaus sv"),
+      opetus = Some(ToteutuksenOpetus),
+      asiasanat = List(Keyword(Fi, "robotiikka"), Keyword(Fi, "robottiautomatiikka")),
+      hakutermi = Some(Hakeutuminen),
+      hakulomaketyyppi = Some(MuuHakulomake),
+      hakulomakeLinkki = Map(Fi -> "http://www.linkki.fi", Sv -> "http://www.linkki.se"),
+      lisatietoaHakeutumisesta = Map(Fi -> "Lisätieto", Sv -> "Lisätieto sv"),
+      lisatietoaValintaperusteista = Map(Fi -> "Lisätieto", Sv -> "Lisätieto sv"),
+      hakuaika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture().plusYears(200)))),
+      yhteyshenkilot = Seq(Yhteystieto1),
+      aloituspaikat = None,
+      isMuokkaajaOphVirkailija = Some(false),
+      hasJotpaRahoitus = Some(false)
+    )
 
   val JulkaistuAmmToteutus: Toteutus = Toteutus(
     oid = None,
@@ -1254,7 +1260,7 @@ object TestData {
     JulkaistuAmmToteutus.copy(
       metadata = Some(KkOpintokokonaisuusToteutuksenMetatieto),
       tarjoajat = List(YoOid, HkiYoOid),
-      koulutuksetKoodiUri = Seq(),
+      koulutuksetKoodiUri = Seq()
     )
   val JulkaistuAmkToteutus: Toteutus =
     JulkaistuAmmToteutus.copy(metadata = Some(YoToteutuksenMetatieto.copy(tyyppi = Amk)), tarjoajat = List(AmkOid))
@@ -1387,7 +1393,8 @@ object TestData {
       lisatietoaValintaperusteista = Map(Fi -> "Lisätieto", Sv -> "Lisätieto sv"),
       hakuaika = Some(Ajanjakso(alkaa = now(), paattyy = Some(inFuture().plusYears(200)))),
       isMuokkaajaOphVirkailija = Some(false),
-      hasJotpaRahoitus = Some(false))
+      hasJotpaRahoitus = Some(false)
+    )
 
   val TaiteenPerusopetusToteutus: Toteutus =
     JulkaistuAmmToteutus.copy(metadata = Some(TaiteenPerusopetusToteutusMetatieto))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -2,6 +2,7 @@ package fi.oph.kouta.integration
 
 import java.time.{Instant, LocalDateTime}
 import fi.oph.kouta.TestData
+import fi.oph.kouta.TestData.{inFuture, now}
 import fi.oph.kouta.TestOids._
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
@@ -10,25 +11,26 @@ import fi.oph.kouta.mocks.MockAuditLogger
 import fi.oph.kouta.security.{Role, RoleEntity}
 import fi.oph.kouta.servlet.KoutaServlet
 import fi.oph.kouta.validation.Validations._
+import org.json4s.jackson.Serialization
 
 class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
 
   override val roleEntities: Seq[RoleEntity] = Seq(Role.Haku)
 
-  val ophHaku: Haku = haku.copy(organisaatioOid = OphOid)
+  val ophHaku: Haku    = haku.copy(organisaatioOid = OphOid)
   val yhteisHaku: Haku = haku.copy(hakutapaKoodiUri = Some("hakutapa_01#1"))
 
   "Get haku by oid" should "return 404 if haku not found" in {
     get("/haku/123", headers = Seq(defaultSessionHeader)) {
-      status should equal (404)
-      body should include ("Unknown haku oid")
+      status should equal(404)
+      body should include("Unknown haku oid")
     }
   }
 
   it should "return 401 without a valid session" in {
     get("/haku/123") {
-      status should equal (401)
-      body should include ("Unauthorized")
+      status should equal(401)
+      body should include("Unauthorized")
     }
   }
 
@@ -104,7 +106,7 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
   }
 
   it should "set haun ohjausparametrit" in {
-    val oid = HakuOid(put(haku))
+    val oid              = HakuOid(put(haku))
     val ohjausparametrit = ohjausparametritClient.mockedValues(oid)
     ohjausparametrit.hakuOid should equal(oid)
     ohjausparametrit.paikanVastaanottoPaattyy should equal(Some(Instant.ofEpochMilli(46800000L)))
@@ -118,7 +120,7 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
   it should "return 401 without a valid session" in {
     put(HakuPath, bytes(haku), Seq(jsonHeader)) {
       status should equal(401)
-      body should include ("Unauthorized")
+      body should include("Unauthorized")
     }
   }
 
@@ -152,29 +154,29 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(invalidAjanjaksoMsg(invalidHakuajat.head), "hakuajat[0]"))
+      body should equal(validationErrorBody(invalidAjanjaksoMsg(invalidHakuajat.head), "hakuajat[0]"))
     }
   }
 
   "Update haku" should "update haku" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku.copy(tila = Arkistoitu), lastModified)
     get(oid, thisHaku.copy(tila = Arkistoitu))
   }
 
   it should "read muokkaaja from the session" in {
-    val oid = put(haku, crudSessions(ChildOid))
-    val userOid = userOidForTestSessionId(crudSessions(ChildOid))
+    val oid          = put(haku, crudSessions(ChildOid))
+    val userOid      = userOidForTestSessionId(crudSessions(ChildOid))
     val lastModified = get(oid, haku(oid).copy(muokkaaja = userOid))
     update(haku(oid, Arkistoitu).copy(muokkaaja = userOid), lastModified)
     get(oid, haku(oid, Arkistoitu).copy(muokkaaja = testUser.oid))
   }
 
   it should "write haku update to audit log" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     MockAuditLogger.clean()
     update(thisHaku.copy(tila = Arkistoitu).withModified(LocalDateTime.parse("1000-01-01T12:00:00")), lastModified)
@@ -183,105 +185,105 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
   }
 
   it should "not update haku" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     MockAuditLogger.clean()
     update(thisHaku, lastModified, expectUpdate = false)
     MockAuditLogger.logs shouldBe empty
-    get(oid, thisHaku) should equal (lastModified)
+    get(oid, thisHaku) should equal(lastModified)
   }
 
   it should "fail update if 'x-If-Unmodified-Since' header is missing" in {
-    val oid = put(haku)
+    val oid      = put(haku)
     val thisHaku = haku(oid)
     get(oid, thisHaku)
     post(HakuPath, bytes(thisHaku), Seq(defaultSessionHeader)) {
-      status should equal (400)
-      body should include (KoutaServlet.IfUnmodifiedSinceHeader)
+      status should equal(400)
+      body should include(KoutaServlet.IfUnmodifiedSinceHeader)
     }
   }
 
   it should "return 401 without a valid session" in {
-    val oid = put(haku)
+    val oid      = put(haku)
     val thisHaku = haku(oid)
     get(oid, thisHaku)
     post(HakuPath, bytes(thisHaku), Map.empty) {
-      status should equal (401)
-      body should include ("Unauthorized")
+      status should equal(401)
+      body should include("Unauthorized")
     }
   }
 
   it should "allow a user of the haku organization to update the haku" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, expectUpdate = false, crudSessions(haku.organisaatioOid))
   }
 
   it should "deny a user without access to the haku organization" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, 403, crudSessions(LonelyOid))
   }
 
   it should "allow a user of an ancestor organization to create the haku" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, expectUpdate = false, crudSessions(ParentOid))
   }
 
   it should "deny a user with only access to a descendant organization" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, 403, crudSessions(GrandChildOid))
   }
 
   it should "deny a user with the wrong role" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, 403, readSessions(haku.organisaatioOid))
   }
 
   it should "allow organisaatioOid change if user had rights to new organisaatio" in {
-    val oid = put(haku.copy(organisaatioOid = HkiYoOid))
-    val thisHaku = haku(oid).copy(organisaatioOid = HkiYoOid)
+    val oid          = put(haku.copy(organisaatioOid = HkiYoOid))
+    val thisHaku     = haku(oid).copy(organisaatioOid = HkiYoOid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku.copy(organisaatioOid = YoOid), lastModified, expectUpdate = true, yliopistotSession)
   }
 
   it should "fail organisaatioOid change if user doesn't have rights to new organisaatio" in {
-    val oid = put(haku.copy(organisaatioOid = HkiYoOid))
-    val thisHaku = haku(oid).copy(organisaatioOid = HkiYoOid)
+    val oid          = put(haku.copy(organisaatioOid = HkiYoOid))
+    val thisHaku     = haku(oid).copy(organisaatioOid = HkiYoOid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku.copy(organisaatioOid = LukioOid), lastModified, 403, yliopistotSession)
   }
 
   it should "deny indexer access" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku, lastModified, 403, indexerSession)
   }
 
   it should "fail update if modified in between get and update" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     Thread.sleep(1500)
     update(thisHaku.copy(tila = Arkistoitu), lastModified)
     post(HakuPath, bytes(thisHaku), headersIfUnmodifiedSince(lastModified)) {
-      status should equal (409)
+      status should equal(409)
     }
   }
 
   it should "delete all hakuajat and read last modified from history" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     Thread.sleep(1500)
     val uusiHaku = thisHaku.copy(hakuajat = List())
@@ -296,7 +298,7 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
     val oid          = put(haku)
     val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
-    val uusiHaku = thisHaku.copy(hakuajat = List())
+    val uusiHaku     = thisHaku.copy(hakuajat = List())
     update(uusiHaku, lastModified, expectUpdate = true)
 
     assert(getTableHistorySize("haut") == 1)
@@ -304,45 +306,118 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
   }
 
   it should "store and update unfinished haku" in {
-    val unfinishedHaku = Haku(muokkaaja = TestUserOid, organisaatioOid = LonelyOid, modified = None, kielivalinta = Seq(Fi), nimi = Map(Fi -> "haku"), kohdejoukkoKoodiUri = Some("haunkohdejoukko_17#1"), hakutapaKoodiUri = Some("hakutapa_03#1"))
+    val unfinishedHaku = Haku(
+      muokkaaja = TestUserOid,
+      organisaatioOid = LonelyOid,
+      modified = None,
+      kielivalinta = Seq(Fi),
+      nimi = Map(Fi -> "haku"),
+      kohdejoukkoKoodiUri = Some("haunkohdejoukko_17#1"),
+      hakutapaKoodiUri = Some("hakutapa_03#1")
+    )
     val oid = put(unfinishedHaku)
-    val lastModified = get(oid, unfinishedHaku.copy(oid = Some(HakuOid(oid)), _enrichedData = Some(HakuEnrichedData(muokkaajanNimi = Some("Testi Muokkaaja")))))
-    val newUnfinishedHaku = unfinishedHaku.copy(oid = Some(HakuOid(oid)), organisaatioOid = AmmOid, _enrichedData = Some(HakuEnrichedData(muokkaajanNimi = Some("Testi Muokkaaja"))))
+    val lastModified = get(
+      oid,
+      unfinishedHaku.copy(
+        oid = Some(HakuOid(oid)),
+        _enrichedData = Some(HakuEnrichedData(muokkaajanNimi = Some("Testi Muokkaaja")))
+      )
+    )
+    val newUnfinishedHaku = unfinishedHaku.copy(
+      oid = Some(HakuOid(oid)),
+      organisaatioOid = AmmOid,
+      _enrichedData = Some(HakuEnrichedData(muokkaajanNimi = Some("Testi Muokkaaja")))
+    )
     update(newUnfinishedHaku, lastModified)
     get(oid, newUnfinishedHaku)
   }
 
   it should "validate updated haku" in {
-    val oid = put(haku)
-    val lastModified = get(oid, haku(oid))
+    val oid             = put(haku)
+    val lastModified    = get(oid, haku(oid))
     val invalidHakuajat = TestData.getInvalidHakuajat
-    val thisHaku = haku(oid).copy(hakuajat = invalidHakuajat)
+    val thisHaku        = haku(oid).copy(hakuajat = invalidHakuajat)
     post(HakuPath, bytes(thisHaku), headersIfUnmodifiedSince(lastModified)) {
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(invalidAjanjaksoMsg(invalidHakuajat.head), "hakuajat[0]"))
+      body should equal(validationErrorBody(invalidAjanjaksoMsg(invalidHakuajat.head), "hakuajat[0]"))
     }
   }
 
   it should "delete all hakuajat if none is given" in {
-    val oid = put(haku)
-    val thisHaku = haku(oid)
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     update(thisHaku.copy(hakuajat = List()), lastModified)
     get(oid, thisHaku.copy(hakuajat = List()))
   }
 
   it should "allow oph user to update from julkaistu to tallennettu" in {
-    val id = put(haku)
+    val id           = put(haku)
     val lastModified = get(id, haku(id))
     update(haku(id).copy(tila = Tallennettu), lastModified, expectUpdate = true, ophSession)
-    get(id, haku(id).copy(tila = Tallennettu, muokkaaja = OphUserOid, metadata = Some(haku.metadata.get.copy(isMuokkaajaOphVirkailija = Some(true)))))
+    get(
+      id,
+      haku(id).copy(
+        tila = Tallennettu,
+        muokkaaja = OphUserOid,
+        metadata = Some(haku.metadata.get.copy(isMuokkaajaOphVirkailija = Some(true)))
+      )
+    )
   }
 
   it should "not allow non oph user to update from julkaistu to tallennettu" in {
-    val id = put(haku)
+    val id           = put(haku)
     val lastModified = get(id, haku(id))
     update(haku(id).copy(tila = Tallennettu), lastModified, 403, crudSessions(haku.organisaatioOid))
+  }
+
+  it should "update muokkaaja of haku on hakuajat insert" in {
+    val hakuWithoutHakuaika        = haku.copy(tila = Tallennettu, hakuajat = List())
+    val oid                        = put(hakuWithoutHakuaika)
+    val hakuWithoutHakuaikaWithOid = hakuWithoutHakuaika.copy(oid = Some(HakuOid(oid)))
+    val lastModified               = get(oid, hakuWithoutHakuaikaWithOid)
+
+    assert(readHakuMuokkaaja(oid) == TestUserOid.toString)
+    get(s"$HakuPath/$oid", headers = defaultHeaders) {
+      status should equal(200)
+      val haku      = Serialization.read[Haku](body)
+      val muokkaaja = haku.muokkaaja
+      muokkaaja.shouldEqual(TestUserOid)
+      assert(haku.hakuajat.size == 0)
+    }
+    update(
+      hakuWithoutHakuaikaWithOid.copy(hakuajat = TestData.getHakuajatWeeksInFuture(1, 3)),
+      lastModified,
+      expectUpdate = true,
+      ophSession
+    )
+    assert(readHakuMuokkaaja(oid) == OphUserOid.toString)
+  }
+
+  it should "update muokkaaja of haku on hakuajat update" in {
+    val hakuWithHakuaika        = haku.copy(tila = Tallennettu, hakuajat = TestData.getHakuajatWeeksInFuture(1, 3))
+    val oid                     = put(hakuWithHakuaika)
+    val hakuWithHakuaikaWithOid = hakuWithHakuaika.copy(oid = Some(HakuOid(oid)))
+    val lastModified            = get(oid, hakuWithHakuaikaWithOid)
+    assert(readHakuMuokkaaja(oid) == TestUserOid.toString)
+
+    update(
+      hakuWithHakuaikaWithOid.copy(hakuajat = TestData.getHakuajatWeeksInFuture(1, 4)),
+      lastModified,
+      expectUpdate = true,
+      ophSession
+    )
+    assert(readHakuMuokkaaja(oid) == OphUserOid.toString)
+  }
+
+  it should "update muokkaaja of haku on hakuajat delete" in {
+    val oid          = put(haku)
+    val thisHaku     = haku(oid)
+    val lastModified = get(oid, thisHaku)
+    assert(readHakuMuokkaaja(oid) == TestUserOid.toString)
+    update(thisHaku.copy(hakuajat = List()), lastModified, expectUpdate = true, ophSession)
+    assert(readHakuMuokkaaja(oid) == OphUserOid.toString)
   }
 }

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -184,13 +184,13 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
     MockAuditLogger.find("1000-01-01") should not be defined
   }
 
-  it should "update muokkaaja and modify timestamp of haku even when nothing changed" in {
+  it should "not update haku" in {
     val oid          = put(haku)
     val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
     MockAuditLogger.clean()
-    update(thisHaku, lastModified, expectUpdate = true)
-    MockAuditLogger.logs should not be empty
+    update(thisHaku, lastModified, expectUpdate = false)
+    MockAuditLogger.logs shouldBe empty
     get(oid, thisHaku) should equal(lastModified)
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -384,26 +384,27 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
   }
 
   it should "update muokkaaja of haku on hakuajat insert" in {
-    val hakuWithoutHakuaika        = haku.copy(tila = Tallennettu, hakuajat = List())
-    val oid                        = put(hakuWithoutHakuaika)
-    val hakuWithoutHakuaikaWithOid = hakuWithoutHakuaika.copy(oid = Some(HakuOid(oid)))
+    val hakuWithoutHakuaika        = haku.copy(tila = Tallennettu, hakuajat = List(),
+      metadata= Some(haku.metadata.get.copy(isMuokkaajaOphVirkailija = Some(true))))
+    val oid                        = put(hakuWithoutHakuaika, ophSession)
+    val hakuWithoutHakuaikaWithOid = hakuWithoutHakuaika.copy(oid = Some(HakuOid(oid)), muokkaaja = OphUserOid)
     val lastModified               = get(oid, hakuWithoutHakuaikaWithOid)
 
-    assert(readHakuMuokkaaja(oid) == TestUserOid.toString)
+    assert(readHakuMuokkaaja(oid) == OphUserOid.toString)
     get(s"$HakuPath/$oid", headers = defaultHeaders) {
       status should equal(200)
       val haku      = Serialization.read[Haku](body)
       val muokkaaja = haku.muokkaaja
-      muokkaaja.shouldEqual(TestUserOid)
+      muokkaaja.shouldEqual(OphUserOid)
       assert(haku.hakuajat.size == 0)
     }
     update(
       hakuWithoutHakuaikaWithOid.copy(hakuajat = TestData.getHakuajatWeeksInFuture(1, 3)),
       lastModified,
       expectUpdate = true,
-      ophSession
+      ophSession2
     )
-    assert(readHakuMuokkaaja(oid) == OphUserOid.toString)
+    assert(readHakuMuokkaaja(oid) == OphUserOid2.toString)
   }
 
   it should "update muokkaaja of haku on hakuajat update" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakuSpec.scala
@@ -184,7 +184,7 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
     MockAuditLogger.find("1000-01-01") should not be defined
   }
 
-  it should "not update haku" in {
+  it should "not update haku with same muokkaaja if nothing changes" in {
     val oid          = put(haku)
     val thisHaku     = haku(oid)
     val lastModified = get(oid, thisHaku)
@@ -192,6 +192,16 @@ class HakuSpec extends KoutaIntegrationSpec with HakuFixture {
     update(thisHaku, lastModified, expectUpdate = false)
     MockAuditLogger.logs shouldBe empty
     get(oid, thisHaku) should equal(lastModified)
+  }
+
+  it should "update haku with different muokkaaja even if nothing changes" in {
+    val oid = put(haku)
+    val thisHaku = haku(oid)
+    val lastModified = get(oid, thisHaku)
+    MockAuditLogger.clean()
+    update(thisHaku, lastModified, expectUpdate = true, crudSessions(haku.organisaatioOid)) // muokkaaja and modify timestamp updated
+    MockAuditLogger.logs should not be empty
+    get(oid, thisHaku.copy(muokkaaja = userOidForTestSessionId(crudSessions(haku.organisaatioOid)))) should equal(lastModified)
   }
 
   it should "fail update if 'x-If-Unmodified-Since' header is missing" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakukohdeSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/HakukohdeSpec.scala
@@ -1,7 +1,7 @@
 package fi.oph.kouta.integration
 
 import fi.oph.kouta.TestData
-import fi.oph.kouta.TestData.{Liite1, Liite2, LukioHakukohteenLinja, LukioKoulutus}
+import fi.oph.kouta.TestData.{Liite1, Liite2, LukioHakukohteenLinja, LukioKoulutus, MinHakukohde}
 import fi.oph.kouta.TestOids._
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid._
@@ -15,7 +15,13 @@ import org.json4s.jackson.Serialization.read
 import java.time.LocalDateTime
 import java.util.UUID
 
-class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with KoulutusFixture with HakuFixture with ValintaperusteFixture with LokalisointiServiceMock {
+class HakukohdeSpec
+    extends KoutaIntegrationSpec
+    with HakukohdeFixture
+    with KoulutusFixture
+    with HakuFixture
+    with ValintaperusteFixture
+    with LokalisointiServiceMock {
 
   override val roleEntities: Seq[RoleEntity] = Seq(Role.Hakukohde)
 
@@ -204,7 +210,10 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
       nimi = Map(),
       metadata = Some(
         hakukohde.metadata.get
-          .copy(valintaperusteenValintakokeidenLisatilaisuudet = Seq(), hakukohteenLinja = Some(LukioHakukohteenLinja.copy(linja = Some("lukiopainotukset_1#1"))))
+          .copy(
+            valintaperusteenValintakokeidenLisatilaisuudet = Seq(),
+            hakukohteenLinja = Some(LukioHakukohteenLinja.copy(linja = Some("lukiopainotukset_1#1")))
+          )
       )
     )
     val oid = put(lkHakukohde)
@@ -479,6 +488,36 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
     get(oid, muokattuHakukohde)
   }
 
+  it should "update hakukohteen muokkaaja on hakuajat change" in {
+    val oid          = put(withValintaperusteenValintakokeet(uusiHakukohde))
+    val lastModified = get(oid, tallennettuHakukohde(oid))
+    assert(readHakukohdeMuokkaaja(oid) == TestUserOid.toString)
+    val muokattuHakukohde = tallennettuHakukohde(oid).copy(
+      hakuajat = List(Ajanjakso(alkaa = TestData.now(), paattyy = Some(TestData.inFuture(12000))))
+    )
+    update(muokattuHakukohde, lastModified, expectUpdate = true, ophSession)
+    assert(readHakukohdeMuokkaaja(oid) == OphUserOid.toString)
+  }
+
+  it should "update hakukohteen muokkaaja on hakuajat delete" in {
+    // ei julkaistu jotta hakuajan voi poistaa
+    val eiJulkaistuHakukohde = withValintaperusteenValintakokeet(uusiHakukohde).copy(
+      tila = Tallennettu,
+      hakuajat = TestData.getHakuajatWeeksInFuture(2, 3),
+      liitteet = List(),
+      valintakokeet = List()
+    )
+    val oid                = put(eiJulkaistuHakukohde)
+    val eiJulkaistuWithOid = eiJulkaistuHakukohde.copy(oid = Some(HakukohdeOid(oid)))
+    val lastModified       = get(oid, eiJulkaistuWithOid)
+    assert(readHakukohdeMuokkaaja(oid) == TestUserOid.toString)
+    val muokattuHakukohde = eiJulkaistuWithOid.copy(
+      hakuajat = List()
+    )
+    update(muokattuHakukohde, lastModified, expectUpdate = true, ophSession)
+    assert(readHakukohdeMuokkaaja(oid) == OphUserOid.toString)
+  }
+
   it should "delete all hakuajat and read last modified from history" in {
     val oid          = put(withValintaperusteenValintakokeet(uusiHakukohde.copy(tila = Tallennettu)))
     val lastModified = get(oid, tallennettuHakukohde(oid).copy(tila = Tallennettu))
@@ -496,7 +535,8 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
 
     val oid          = put(withValintaperusteenValintakokeet(uusiHakukohde.copy(tila = Tallennettu)))
     val lastModified = get(oid, tallennettuHakukohde(oid).copy(tila = Tallennettu))
-    val muokattuHakukohde = tallennettuHakukohde(oid).copy(liitteet = List(), hakuajat = List(), valintakokeet = List(), tila = Tallennettu)
+    val muokattuHakukohde =
+      tallennettuHakukohde(oid).copy(liitteet = List(), hakuajat = List(), valintakokeet = List(), tila = Tallennettu)
     update(muokattuHakukohde, lastModified, expectUpdate = true)
 
     assert(getTableHistorySize("hakukohteet") == 1)
@@ -556,6 +596,30 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
     )
     update(muokattuHakukohde, lastModified, expectUpdate = true)
     get(oid, getIds(muokattuHakukohde))
+  }
+
+  it should "update muokkaaja on liitteet change" in {
+    val oid         = put(withValintaperusteenValintakokeet(uusiHakukohde))
+    val tallennettu = tallennettuHakukohde(oid)
+    assert(readHakukohdeMuokkaaja(oid) == TestUserOid.toString)
+    val lastModified = get(oid, tallennettu)
+    val muokattuHakukohde = tallennettu.copy(
+      liitteet = tallennettu.liitteet.map(_.copy(toimitusaika = Some(TestData.inFuture(9000))))
+    )
+    update(muokattuHakukohde, lastModified, expectUpdate = true, ophSession)
+    assert(readHakukohdeMuokkaaja(oid) == OphUserOid.toString)
+  }
+
+  it should "update muokkaaja on valintakokeet change" in {
+    val oid         = put(withValintaperusteenValintakokeet(uusiHakukohde))
+    val tallennettu = tallennettuHakukohde(oid)
+    assert(readHakukohdeMuokkaaja(oid) == TestUserOid.toString)
+    val lastModified = get(oid, tallennettu)
+    val muokattuHakukohde = tallennettu.copy(
+      valintakokeet = List(TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_42#2")))
+    )
+    update(muokattuHakukohde, lastModified, expectUpdate = true, ophSession)
+    assert(readHakukohdeMuokkaaja(oid) == OphUserOid.toString)
   }
 
   it should "put, update and delete valintakokeet correctly" in {
@@ -713,15 +777,18 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
   }
 
   "Change hakukohteet tila" should "change two julkaistu hakukohteet to arkistoitu when muokkaaja is OPH virkailija" in {
-    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq())
-    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq())
+    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId))
+      .copy(liitteet = Seq(), valintakokeet = Seq())
+    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId))
+      .copy(liitteet = Seq(), valintakokeet = Seq())
 
     val julkaistuHakukohde1Oid = put(julkaistuHakukohde1)
     val julkaistuHakukohde2Oid = put(julkaistuHakukohde2)
 
     val hakukohteet = List(julkaistuHakukohde1Oid, julkaistuHakukohde2Oid)
 
-    val lastModified = get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
+    val lastModified =
+      get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
     val response = changeTila(hakukohteet, "arkistoitu", lastModified, ophSession, 200)
 
     val metadata1 = julkaistuHakukohde1.metadata.get
@@ -746,22 +813,24 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
     response.last.oid.toString shouldBe julkaistuHakukohde2Oid
     response.last.status shouldBe "success"
 
-
     get(julkaistuHakukohde1Oid, arkistoituHakukohde1)
     get(julkaistuHakukohde2Oid, arkistoituHakukohde2)
   }
 
   it should "fail to change tila of hakukohteet from julkaistu to arkistoitu when muokkaaja is non oph user and contains random hakukohdeOid" in {
-    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq())
-    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq())
+    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId))
+      .copy(liitteet = Seq(), valintakokeet = Seq())
+    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId))
+      .copy(liitteet = Seq(), valintakokeet = Seq())
 
     val julkaistuHakukohde1Oid = put(julkaistuHakukohde1)
     val julkaistuHakukohde2Oid = put(julkaistuHakukohde2)
-    val randomOid = randomHakukohdeOid.toString
+    val randomOid              = randomHakukohdeOid.toString
 
     val hakukohteet = List(julkaistuHakukohde1Oid, randomOid, julkaistuHakukohde2Oid)
 
-    val lastModified = get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
+    val lastModified =
+      get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
     val response = changeTila(hakukohteet, "arkistoitu", lastModified, crudSessions(LonelyOid), 200)
 
     response.length shouldBe 3
@@ -786,15 +855,24 @@ class HakukohdeSpec extends KoutaIntegrationSpec with HakukohdeFixture with Koul
   }
 
   it should "allow to change tila of hakukohteet from julkaistu to arkistoitu when muokkaaja has rights to hakukohde" in {
-    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq(), jarjestyspaikkaOid = Some(ChildOid))
-    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(liitteet = Seq(), valintakokeet = Seq(), jarjestyspaikkaOid = Some(ChildOid))
+    val julkaistuHakukohde1 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(
+      liitteet = Seq(),
+      valintakokeet = Seq(),
+      jarjestyspaikkaOid = Some(ChildOid)
+    )
+    val julkaistuHakukohde2 = withValintaperusteenValintakokeet(hakukohde(toteutusOid, hakuOid, valintaperusteId)).copy(
+      liitteet = Seq(),
+      valintakokeet = Seq(),
+      jarjestyspaikkaOid = Some(ChildOid)
+    )
 
     val julkaistuHakukohde1Oid = put(julkaistuHakukohde1)
     val julkaistuHakukohde2Oid = put(julkaistuHakukohde2)
 
     val hakukohteet = List(julkaistuHakukohde1Oid, julkaistuHakukohde2Oid)
 
-    val lastModified = get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
+    val lastModified =
+      get(julkaistuHakukohde1Oid, julkaistuHakukohde1.copy(oid = Some(HakukohdeOid(julkaistuHakukohde1Oid))))
     val response = changeTila(hakukohteet, "arkistoitu", lastModified, ammAndChildSession, 200)
 
     response.length shouldBe 2

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -249,10 +249,10 @@ class KoulutusSpec
     get(oid, koulutus(oid, Arkistoitu))
   }
 
-  "Update koulutus" should "update koulutus timestamp and muokkaaja even without changes" in {
+  "Update koulutus" should " not update koulutus without changes" in {
     val oid = put(koulutus, ophSession)
     val lastModified = get(oid, koulutus(oid))
-    update(koulutus(oid), lastModified, expectUpdate = true, ophSession)
+    update(koulutus(oid), lastModified, expectUpdate = false, ophSession)
     get(oid, koulutus(oid))
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -448,82 +448,67 @@ class KoulutusSpec
   }
 
   it should "update muokkaaja of the koulutus when tarjoaja is added" in {
-    logger.info(s"luodaan")
     var muokattavaKoulutus = KkOpintokokonaisuusKoulutus.copy(
       metadata = Some(KkOpintokokonaisuusKoulutuksenMetatieto.copy(isAvoinKorkeakoulutus = Some(true))),
       organisaatioOid = YoOid,
       tarjoajat = List(YoOid)
     )
-    logger.info(s"tarjoajia " + muokattavaKoulutus.tarjoajat.size)
     val oid = put(muokattavaKoulutus)
     muokattavaKoulutus = muokattavaKoulutus.copy(oid = Some(KoulutusOid(oid)))
     // haetaan kannasta asti
     assert(getKoulutusMuokkaaja(muokattavaKoulutus) == TestUserOid.toString)
-    logger.info(s"haetaan ")
     get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
       status should equal(200)
 
       val koulutus  = read[Koulutus](body)
       val muokkaaja = koulutus.muokkaaja
-      logger.info(s"muokkaaja apista: " + muokkaaja)
       muokkaaja.shouldEqual(TestUserOid)
 
     }
     val lastModified = get(oid, muokattavaKoulutus)
     val updatedKoulutus =
       muokattavaKoulutus.copy(tarjoajat = HkiYoOid :: muokattavaKoulutus.tarjoajat)
-    logger.info(s"tarjoajia " + updatedKoulutus.tarjoajat.size)
-    logger.info(s"päivitetään ")
     update(updatedKoulutus, lastModified, expectUpdate = true, ophSession)
-    logger.info(s"haetaan ")
     assert(getKoulutusMuokkaaja(muokattavaKoulutus) == OphUserOid.toString)
     get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
       status should equal(200)
 
       val koulutus  = read[Koulutus](body)
       val muokkaaja = koulutus.muokkaaja
-      logger.info(s"muokkaaja apista2: ", muokkaaja)
       muokkaaja.shouldEqual(OphUserOid)
+      assert(koulutus.tarjoajat.size == 2)
     }
   }
 
   it should "update muokkaaja of the koulutus when tarjoaja is deleted" in {
-    logger.info(s"luodaan")
     var muokattavaKoulutus = KkOpintokokonaisuusKoulutus.copy(
       metadata = Some(KkOpintokokonaisuusKoulutuksenMetatieto.copy(isAvoinKorkeakoulutus = Some(true))),
       organisaatioOid = YoOid,
       tarjoajat = List(YoOid, HkiYoOid)
     )
-    logger.info(s"tarjoajia " + muokattavaKoulutus.tarjoajat.size)
     val oid = put(muokattavaKoulutus)
     muokattavaKoulutus = muokattavaKoulutus.copy(oid = Some(KoulutusOid(oid)))
     // haetaan kannasta asti
     assert(getKoulutusMuokkaaja(muokattavaKoulutus) == TestUserOid.toString)
-    logger.info(s"haetaan ")
     get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
       status should equal(200)
 
       val koulutus  = read[Koulutus](body)
       val muokkaaja = koulutus.muokkaaja
-      logger.info(s"muokkaaja apista: " + muokkaaja)
       muokkaaja.shouldEqual(TestUserOid)
-
     }
     val lastModified = get(oid, muokattavaKoulutus)
     val updatedKoulutus =
       muokattavaKoulutus.copy(tarjoajat = List(HkiYoOid))
-    logger.info(s"tarjoajia " + updatedKoulutus.tarjoajat.size)
-    logger.info(s"päivitetään ")
     update(updatedKoulutus, lastModified, expectUpdate = true, ophSession)
-    logger.info(s"haetaan ")
     assert(getKoulutusMuokkaaja(muokattavaKoulutus) == OphUserOid.toString)
     get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
       status should equal(200)
 
       val koulutus  = read[Koulutus](body)
       val muokkaaja = koulutus.muokkaaja
-      logger.info(s"muokkaaja apista2: ", muokkaaja)
       muokkaaja.shouldEqual(OphUserOid)
+      assert(koulutus.tarjoajat.size == 1)
     }
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -447,13 +447,14 @@ class KoulutusSpec
     }
   }
 
-  it should "update muokkaaja of the koulutus even when just tarjoajat is updated" in {
+  it should "update muokkaaja of the koulutus when tarjoaja is added" in {
     logger.info(s"luodaan")
     var muokattavaKoulutus = KkOpintokokonaisuusKoulutus.copy(
       metadata = Some(KkOpintokokonaisuusKoulutuksenMetatieto.copy(isAvoinKorkeakoulutus = Some(true))),
       organisaatioOid = YoOid,
       tarjoajat = List(YoOid)
     )
+    logger.info(s"tarjoajia " + muokattavaKoulutus.tarjoajat.size)
     val oid = put(muokattavaKoulutus)
     muokattavaKoulutus = muokattavaKoulutus.copy(oid = Some(KoulutusOid(oid)))
     // haetaan kannasta asti
@@ -462,7 +463,7 @@ class KoulutusSpec
     get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
       status should equal(200)
 
-      val koulutus = read[Koulutus](body)
+      val koulutus  = read[Koulutus](body)
       val muokkaaja = koulutus.muokkaaja
       logger.info(s"muokkaaja apista: " + muokkaaja)
       muokkaaja.shouldEqual(TestUserOid)
@@ -471,6 +472,47 @@ class KoulutusSpec
     val lastModified = get(oid, muokattavaKoulutus)
     val updatedKoulutus =
       muokattavaKoulutus.copy(tarjoajat = HkiYoOid :: muokattavaKoulutus.tarjoajat)
+    logger.info(s"tarjoajia " + updatedKoulutus.tarjoajat.size)
+    logger.info(s"päivitetään ")
+    update(updatedKoulutus, lastModified, expectUpdate = true, ophSession)
+    logger.info(s"haetaan ")
+    assert(getKoulutusMuokkaaja(muokattavaKoulutus) == OphUserOid.toString)
+    get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
+      status should equal(200)
+
+      val koulutus  = read[Koulutus](body)
+      val muokkaaja = koulutus.muokkaaja
+      logger.info(s"muokkaaja apista2: ", muokkaaja)
+      muokkaaja.shouldEqual(OphUserOid)
+    }
+  }
+
+  it should "update muokkaaja of the koulutus when tarjoaja is deleted" in {
+    logger.info(s"luodaan")
+    var muokattavaKoulutus = KkOpintokokonaisuusKoulutus.copy(
+      metadata = Some(KkOpintokokonaisuusKoulutuksenMetatieto.copy(isAvoinKorkeakoulutus = Some(true))),
+      organisaatioOid = YoOid,
+      tarjoajat = List(YoOid, HkiYoOid)
+    )
+    logger.info(s"tarjoajia " + muokattavaKoulutus.tarjoajat.size)
+    val oid = put(muokattavaKoulutus)
+    muokattavaKoulutus = muokattavaKoulutus.copy(oid = Some(KoulutusOid(oid)))
+    // haetaan kannasta asti
+    assert(getKoulutusMuokkaaja(muokattavaKoulutus) == TestUserOid.toString)
+    logger.info(s"haetaan ")
+    get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
+      status should equal(200)
+
+      val koulutus  = read[Koulutus](body)
+      val muokkaaja = koulutus.muokkaaja
+      logger.info(s"muokkaaja apista: " + muokkaaja)
+      muokkaaja.shouldEqual(TestUserOid)
+
+    }
+    val lastModified = get(oid, muokattavaKoulutus)
+    val updatedKoulutus =
+      muokattavaKoulutus.copy(tarjoajat = List(HkiYoOid))
+    logger.info(s"tarjoajia " + updatedKoulutus.tarjoajat.size)
     logger.info(s"päivitetään ")
     update(updatedKoulutus, lastModified, expectUpdate = true, ophSession)
     logger.info(s"haetaan ")

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -249,6 +249,13 @@ class KoulutusSpec
     get(oid, koulutus(oid, Arkistoitu))
   }
 
+  "Update koulutus" should "update koulutus timestamp and muokkaaja even without changes" in {
+    val oid = put(koulutus, ophSession)
+    val lastModified = get(oid, koulutus(oid))
+    update(koulutus(oid), lastModified, expectUpdate = true, ophSession)
+    get(oid, koulutus(oid))
+  }
+
   it should "read muokkaaja from the session" in {
     val oid          = put(koulutus, ophSession)
     val userOid      = OphUserOid

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoulutusSpec.scala
@@ -12,7 +12,7 @@ import fi.oph.kouta.servlet.KoutaServlet
 import fi.oph.kouta.util.TimeUtils
 import fi.oph.kouta.validation.ValidationError
 import fi.oph.kouta.validation.Validations._
-import fi.oph.kouta.util.TimeUtils.{instantToModified, modifiedToInstant}
+import fi.oph.kouta.util.TimeUtils.{instantToModified, modifiedToInstant, renderHttpDate}
 import org.json4s.jackson.Serialization.read
 
 import java.time.{Duration, Instant, LocalDateTime, ZoneId}
@@ -447,6 +447,44 @@ class KoulutusSpec
     }
   }
 
+  it should "update muokkaaja of the koulutus even when just tarjoajat is updated" in {
+    logger.info(s"luodaan")
+    var muokattavaKoulutus = KkOpintokokonaisuusKoulutus.copy(
+      metadata = Some(KkOpintokokonaisuusKoulutuksenMetatieto.copy(isAvoinKorkeakoulutus = Some(true))),
+      organisaatioOid = YoOid,
+      tarjoajat = List(YoOid)
+    )
+    val oid = put(muokattavaKoulutus)
+    muokattavaKoulutus = muokattavaKoulutus.copy(oid = Some(KoulutusOid(oid)))
+    // haetaan kannasta asti
+    assert(getKoulutusMuokkaaja(muokattavaKoulutus) == TestUserOid.toString)
+    logger.info(s"haetaan ")
+    get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
+      status should equal(200)
+
+      val koulutus = read[Koulutus](body)
+      val muokkaaja = koulutus.muokkaaja
+      logger.info(s"muokkaaja apista: " + muokkaaja)
+      muokkaaja.shouldEqual(TestUserOid)
+
+    }
+    val lastModified = get(oid, muokattavaKoulutus)
+    val updatedKoulutus =
+      muokattavaKoulutus.copy(tarjoajat = HkiYoOid :: muokattavaKoulutus.tarjoajat)
+    logger.info(s"päivitetään ")
+    update(updatedKoulutus, lastModified, expectUpdate = true, ophSession)
+    logger.info(s"haetaan ")
+    assert(getKoulutusMuokkaaja(muokattavaKoulutus) == OphUserOid.toString)
+    get(s"$KoulutusPath/$oid", headers = defaultHeaders) {
+      status should equal(200)
+
+      val koulutus  = read[Koulutus](body)
+      val muokkaaja = koulutus.muokkaaja
+      logger.info(s"muokkaaja apista2: ", muokkaaja)
+      muokkaaja.shouldEqual(OphUserOid)
+    }
+  }
+
   it should "delete some tarjoajat and read last modified from history" in {
     val oid          = put(koulutus, ophSession)
     val lastModified = get(oid, koulutus(oid))
@@ -470,8 +508,8 @@ class KoulutusSpec
     val koulutus2NewTarjoajat       = koulutus2.tarjoajat ++ Seq(YoOid)
     val koulutus2tarjoajatTimestamp = updateKoulutusTarjoajat(koulutus2.copy(tarjoajat = koulutus2NewTarjoajat))
 
-    val (koulutus3, _)        = insertKoulutus(koulutus)
-    val oid3                  = koulutus3.oid.get.toString
+    val (koulutus3, _)              = insertKoulutus(koulutus)
+    val oid3                        = koulutus3.oid.get.toString
     val koulutus3tarjoajatTimestamp = updateKoulutusTarjoajat(koulutus3.copy(tarjoajat = List()))
 
     db.migrate("107")
@@ -624,7 +662,7 @@ class KoulutusSpec
 
   it should "set koulutuksetKoodiUri of taiteen perusopetus koulutus automatically if not given" in {
     val tpoKoulutus = TaiteenPerusopetusKoulutus.copy(koulutuksetKoodiUri = Seq())
-    val oid          = put(tpoKoulutus)
+    val oid         = put(tpoKoulutus)
     get(oid, tpoKoulutus.copy(oid = Some(KoulutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_999907#1")))
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/KoutaIntegrationSpec.scala
@@ -94,6 +94,7 @@ trait AccessControlSpec extends ScalatraFlatSpec {
   val readSessions: mutable.Map[OrganisaatioOid, UUID] = mutable.Map.empty
 
   var ophSession: UUID         = _
+  var ophSession2: UUID         = _
   var indexerSession: UUID     = _
   var fakeIndexerSession: UUID = _
   var otherRoleSession: UUID = _
@@ -146,6 +147,7 @@ trait AccessControlSpec extends ScalatraFlatSpec {
     yliopistotSession = addTestSession(roleEntities.map(_.Crud.asInstanceOf[Role]), Seq(YoOid, HkiYoOid, LutYoOid), None, Option(yliopistotSession))
     ammAndChildSession = addTestSession(roleEntities.map(_.Crud.asInstanceOf[Role]), Seq(AmmOid, ChildOid), None, Option(ammAndChildSession))
     ophSession = addTestSession(Seq(Role.Paakayttaja), Seq(OphOid), Some(OphUserOid), Option(ophSession))
+    ophSession2 = addTestSession(Seq(Role.Paakayttaja), Seq(OphOid), Some(OphUserOid2), Option(ophSession2))
     indexerSession = addTestSession(Seq(Role.Indexer), Seq(OphOid), None, Option(indexerSession))
     fakeIndexerSession = addTestSession(Seq(Role.Indexer), Seq(ChildOid), None, Option(fakeIndexerSession))
     otherRoleSession = addTestSession(Seq(Role.UnknownRole("APP_OTHER")), Seq(ChildOid), None, Option(otherRoleSession))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -525,7 +525,7 @@ class ToteutusSpec
     val oid          = put(toteutus(koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid))
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, expectUpdate = true, ammAndChildSession) // muokkaaja and last_modified are updated
+    update(thisToteutus, lastModified, expectUpdate = false, ammAndChildSession)
   }
 
   it should "deny a user without access to the toteutus organization" in {
@@ -546,7 +546,7 @@ class ToteutusSpec
     val oid          = put(toteutus(koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(GrandChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(GrandChildOid))
     val lastModified = get(oid, thisToteutus)
-    update(thisToteutus, lastModified, expectUpdate = true, crudSessions(ParentOid)) // last_modified and muokkaaja are updated
+    update(thisToteutus, lastModified, expectUpdate = false, crudSessions(ParentOid))
   }
 
   it should "deny a user with only access to a descendant organization" in {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -375,7 +375,7 @@ class ToteutusSpec
     val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = userOidForTestSessionId(session))
     val lastModified    = get(oid, createdToteutus)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(AmmOid)))
-    update(createdToteutus.copy(tarjoajat = List(AmmOid, GrandChildOid)), lastModified)
+    update(createdToteutus.copy(tarjoajat = List(AmmOid, GrandChildOid)), lastModified, expectUpdate = true, session)
     get(oid, createdToteutus.copy(tarjoajat = List(AmmOid, GrandChildOid)))
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(AmmOid, ChildOid)))
   }

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -15,10 +15,17 @@ import fi.oph.kouta.util.TimeUtils.instantToModified
 import org.json4s.jackson.JsonMethods
 import java.time.LocalDateTime
 
-class ToteutusSpec extends KoutaIntegrationSpec
-  with AccessControlSpec with KoulutusFixture with ToteutusFixture with SorakuvausFixture
-  with KeywordFixture with UploadFixture with LokalisointiServiceMock
-  with HakukohdeFixture with HakuFixture {
+class ToteutusSpec
+    extends KoutaIntegrationSpec
+    with AccessControlSpec
+    with KoulutusFixture
+    with ToteutusFixture
+    with SorakuvausFixture
+    with KeywordFixture
+    with UploadFixture
+    with LokalisointiServiceMock
+    with HakukohdeFixture
+    with HakuFixture {
 
   override val roleEntities: Seq[RoleEntity] = Seq(Role.Toteutus, Role.Koulutus)
 
@@ -33,14 +40,14 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   "Get toteutus by oid" should "return 404 if toteutus not found" in {
     get(s"$ToteutusPath/123", headers = defaultHeaders) {
-      status should equal (404)
-      body should include ("Unknown toteutus oid")
+      status should equal(404)
+      body should include("Unknown toteutus oid")
     }
   }
 
   it should "return 401 if no session is found" in {
     get(s"$ToteutusPath/123") {
-      status should equal (401)
+      status should equal(401)
     }
   }
 
@@ -101,15 +108,25 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "store korkeakoulutus toteutus" in {
     val koulutusOid = put(TestData.YoKoulutus, ophSession)
-    val oid = put(TestData.JulkaistuYoToteutus.copy(koulutusOid = KoulutusOid(koulutusOid)))
-    get(oid, TestData.JulkaistuYoToteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid), koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1")))
+    val oid         = put(TestData.JulkaistuYoToteutus.copy(koulutusOid = KoulutusOid(koulutusOid)))
+    get(
+      oid,
+      TestData.JulkaistuYoToteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        koulutusOid = KoulutusOid(koulutusOid),
+        koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1")
+      )
+    )
   }
 
   it should "add toteutuksen tarjoajan oppilaitos to koulutuksen tarjoajat if it's not there" in {
     val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List())
     val koulutusOid = put(ophKoulutus, ophSession)
     val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = GrandChildOid, tarjoajat = List(GrandChildOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]), Seq(GrandChildOid))
+    val session = addTestSession(
+      Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]),
+      Seq(GrandChildOid)
+    )
     val oid = put(newToteutus, session)
     get(oid, newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = userOidForTestSessionId(session)))
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(ChildOid)))
@@ -119,7 +136,10 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val newKoulutus = koulutus.copy(organisaatioOid = LonelyOid, julkinen = false, tarjoajat = List(LonelyOid))
     val koulutusOid = put(newKoulutus, ophSession)
     val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = GrandChildOid, tarjoajat = List(GrandChildOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]), Seq(GrandChildOid))
+    val session = addTestSession(
+      Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]),
+      Seq(GrandChildOid)
+    )
     put(ToteutusPath, newToteutus, session, 403)
     get(koulutusOid, newKoulutus.copy(oid = Some(KoulutusOid(koulutusOid))))
   }
@@ -128,7 +148,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List())
     val koulutusOid = put(ophKoulutus, ophSession)
     val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = GrandChildOid, tarjoajat = List(GrandChildOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role]), Seq(GrandChildOid))
+    val session     = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role]), Seq(GrandChildOid))
     put(ToteutusPath, newToteutus, session, 403)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid))))
   }
@@ -146,16 +166,20 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "return 401 if no session is found" in {
     put(ToteutusPath, bytes(toteutus(koulutusOid))) {
-      status should equal (401)
+      status should equal(401)
     }
   }
 
   it should "validate new toteutus" in {
-    put(ToteutusPath, bytes(toteutus(koulutusOid).copy(tarjoajat = List("katkarapu").map(OrganisaatioOid))), defaultHeaders) {
+    put(
+      ToteutusPath,
+      bytes(toteutus(koulutusOid).copy(tarjoajat = List("katkarapu").map(OrganisaatioOid))),
+      defaultHeaders
+    ) {
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(validationMsg("katkarapu"), "tarjoajat[0]"))
+      body should equal(validationErrorBody(validationMsg("katkarapu"), "tarjoajat[0]"))
     }
   }
 
@@ -168,15 +192,25 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   it should "deny a user without access to the toteutus organization" in {
-    put(ToteutusPath, toteutus(koulutusOid).copy(tarjoajat = List(toteutus.organisaatioOid)), crudSessions(LonelyOid), 403)
+    put(
+      ToteutusPath,
+      toteutus(koulutusOid).copy(tarjoajat = List(toteutus.organisaatioOid)),
+      crudSessions(LonelyOid),
+      403
+    )
   }
 
   it should "deny a user without access to tarjoaja organizations" in {
-    put(ToteutusPath, toteutus(koulutusOid).copy(tarjoajat = List(OtherOid)), crudSessions(toteutus.organisaatioOid), 403)
+    put(
+      ToteutusPath,
+      toteutus(koulutusOid).copy(tarjoajat = List(OtherOid)),
+      crudSessions(toteutus.organisaatioOid),
+      403
+    )
   }
 
   it should "allow a user of an ancestor organization to create the toteutus" in {
-     put(toteutus(koulutusOid).copy(tarjoajat = List(GrandChildOid)), crudSessions(ParentOid))
+    put(toteutus(koulutusOid).copy(tarjoajat = List(GrandChildOid)), crudSessions(ParentOid))
   }
 
   it should "deny a user with only access to a descendant organization" in {
@@ -202,7 +236,8 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   it should "not touch an image that's not in the temporary location" in {
-    val toteutusWithImage = toteutus(koulutusOid).withTeemakuva(Some(s"$PublicImageServer/kuvapankki-tai-joku/image.png"))
+    val toteutusWithImage =
+      toteutus(koulutusOid).withTeemakuva(Some(s"$PublicImageServer/kuvapankki-tai-joku/image.png"))
     val oid = put(toteutusWithImage)
     MockS3Client.storage shouldBe empty
     get(oid, toteutusWithImage.copy(oid = Some(ToteutusOid(oid))))
@@ -215,20 +250,24 @@ class ToteutusSpec extends KoutaIntegrationSpec
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(notMissingMsg(Some(sorakuvausId)), "sorakuvausId"))
+      body should equal(validationErrorBody(notMissingMsg(Some(sorakuvausId)), "sorakuvausId"))
     }
   }
 
   it should "fail to store julkaistu opintokokonaisuus if attached opintojakso is not julkaistu" in {
     val julkaistuOpintojaksoKoulutus = KkOpintojaksoKoulutus
-    val opintojaksoKoulutusOid = put(julkaistuOpintojaksoKoulutus)
-    val tallennettuKkOpintojaksoToteutus = JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid), tila = Tallennettu)
-    val opintojaksoToteutusOid = put(tallennettuKkOpintojaksoToteutus)
+    val opintojaksoKoulutusOid       = put(julkaistuOpintojaksoKoulutus)
+    val tallennettuKkOpintojaksoToteutus =
+      JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid), tila = Tallennettu)
+    val opintojaksoToteutusOid               = put(tallennettuKkOpintojaksoToteutus)
     val julkaistuKkOpintokokonaisuusKoulutus = KkOpintokokonaisuusKoulutus
-    val opintokokonaisuusKoulutusOid = put(julkaistuKkOpintokokonaisuusKoulutus)
+    val opintokokonaisuusKoulutusOid         = put(julkaistuKkOpintokokonaisuusKoulutus)
     val julkaistuKkOpintokokonaisuusToteutus = JulkaistuKkOpintokokonaisuusToteutus.copy(
       koulutusOid = KoulutusOid(opintokokonaisuusKoulutusOid),
-      metadata = Some(KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))))
+      metadata = Some(
+        KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))
+      )
+    )
     put(ToteutusPath, bytes(julkaistuKkOpintokokonaisuusToteutus), defaultHeaders) {
       withClue(body) {
         status should equal(400)
@@ -240,21 +279,35 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "fail to update opintokokonaisuus tila to julkaistu if attached opintojakso is not julkaistu" in {
     val julkaistuOpintojaksoKoulutus = KkOpintojaksoKoulutus
-    val opintojaksoKoulutusOid = put(julkaistuOpintojaksoKoulutus)
-    val tallennettuKkOpintojaksoToteutus = JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid), tila = Tallennettu)
-    val opintojaksoToteutusOid = put(tallennettuKkOpintojaksoToteutus)
+    val opintojaksoKoulutusOid       = put(julkaistuOpintojaksoKoulutus)
+    val tallennettuKkOpintojaksoToteutus =
+      JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid), tila = Tallennettu)
+    val opintojaksoToteutusOid               = put(tallennettuKkOpintojaksoToteutus)
     val julkaistuKkOpintokokonaisuusKoulutus = KkOpintokokonaisuusKoulutus
-    val opintokokonaisuusKoulutusOid = put(julkaistuKkOpintokokonaisuusKoulutus)
+    val opintokokonaisuusKoulutusOid         = put(julkaistuKkOpintokokonaisuusKoulutus)
     val tallennettuKkOpintokokonaisuusToteutus = JulkaistuKkOpintokokonaisuusToteutus.copy(
       tila = Tallennettu,
       koulutusOid = KoulutusOid(opintokokonaisuusKoulutusOid),
-      metadata = Some(KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))))
+      metadata = Some(
+        KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))
+      )
+    )
     val tallennettuKkOpintokokonaisuusToteutusOid = put(tallennettuKkOpintokokonaisuusToteutus)
-    val lastModified = get(tallennettuKkOpintokokonaisuusToteutusOid, tallennettuKkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(tallennettuKkOpintokokonaisuusToteutusOid))))
+    val lastModified = get(
+      tallennettuKkOpintokokonaisuusToteutusOid,
+      tallennettuKkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(tallennettuKkOpintokokonaisuusToteutusOid)))
+    )
     post(
       ToteutusPath,
-      bytes(tallennettuKkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(tallennettuKkOpintokokonaisuusToteutusOid)), koulutusOid = KoulutusOid(opintokokonaisuusKoulutusOid), tila = Julkaistu)),
-      headersIfUnmodifiedSince(lastModified)) {
+      bytes(
+        tallennettuKkOpintokokonaisuusToteutus.copy(
+          oid = Some(ToteutusOid(tallennettuKkOpintokokonaisuusToteutusOid)),
+          koulutusOid = KoulutusOid(opintokokonaisuusKoulutusOid),
+          tila = Julkaistu
+        )
+      ),
+      headersIfUnmodifiedSince(lastModified)
+    ) {
       withClue(body) {
         status should equal(400)
       }
@@ -265,36 +318,43 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "succeed to update opintokokonaisuus tila to julkaistu when attached opintojakso is julkaistu" in {
     val julkaistuOpintojaksoKoulutus = KkOpintojaksoKoulutus
-    val opintojaksoKoulutusOid = put(julkaistuOpintojaksoKoulutus)
-    val julkaistuKkOpintojaksoToteutus = JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid))
-    val opintojaksoToteutusOid = put(julkaistuKkOpintojaksoToteutus)
+    val opintojaksoKoulutusOid       = put(julkaistuOpintojaksoKoulutus)
+    val julkaistuKkOpintojaksoToteutus =
+      JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(opintojaksoKoulutusOid))
+    val opintojaksoToteutusOid               = put(julkaistuKkOpintojaksoToteutus)
     val julkaistuKkOpintokokonaisuusKoulutus = KkOpintokokonaisuusKoulutus
-    val opintokokonaisuusKoulutusOid = put(julkaistuKkOpintokokonaisuusKoulutus)
+    val opintokokonaisuusKoulutusOid         = put(julkaistuKkOpintokokonaisuusKoulutus)
     val julkaistuKkOpintokokonaisuusToteutus = JulkaistuKkOpintokokonaisuusToteutus.copy(
       koulutusOid = KoulutusOid(opintokokonaisuusKoulutusOid),
-      metadata = Some(KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))))
+      metadata = Some(
+        KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(opintojaksoToteutusOid)))
+      )
+    )
     put(ToteutusPath, bytes(julkaistuKkOpintokokonaisuusToteutus), defaultHeaders) {
       status should equal(200)
     }
   }
 
   "Update toteutus" should "update toteutus" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
     update(toteutus(oid, koulutusOid, Arkistoitu), lastModified)
     get(oid, toteutus(oid, koulutusOid, Arkistoitu))
   }
 
   it should "read muokkaaja from the session" in {
-    val oid = put(toteutus(koulutusOid).copy(tarjoajat = List(GrandChildOid)), crudSessions(ChildOid))
-    val userOid = userOidForTestSessionId(crudSessions(ChildOid))
+    val oid          = put(toteutus(koulutusOid).copy(tarjoajat = List(GrandChildOid)), crudSessions(ChildOid))
+    val userOid      = userOidForTestSessionId(crudSessions(ChildOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid).copy(muokkaaja = userOid, tarjoajat = List(GrandChildOid)))
-    update(toteutus(oid, koulutusOid, Arkistoitu).copy(muokkaaja = userOid, tarjoajat = List(GrandChildOid)), lastModified)
+    update(
+      toteutus(oid, koulutusOid, Arkistoitu).copy(muokkaaja = userOid, tarjoajat = List(GrandChildOid)),
+      lastModified
+    )
     get(oid, toteutus(oid, koulutusOid, Arkistoitu).copy(muokkaaja = testUser.oid, tarjoajat = List(GrandChildOid)))
   }
 
   it should "not update toteutus" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     MockAuditLogger.clean()
@@ -307,10 +367,13 @@ class ToteutusSpec extends KoutaIntegrationSpec
     val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List())
     val koulutusOid = put(ophKoulutus, ophSession)
     val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = AmmOid, tarjoajat = List(AmmOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]), Seq(AmmOid, GrandChildOid))
-    val oid = put(newToteutus, session)
+    val session = addTestSession(
+      Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]),
+      Seq(AmmOid, GrandChildOid)
+    )
+    val oid             = put(newToteutus, session)
     val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = userOidForTestSessionId(session))
-    val lastModified = get(oid, createdToteutus)
+    val lastModified    = get(oid, createdToteutus)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(AmmOid)))
     update(createdToteutus.copy(tarjoajat = List(AmmOid, GrandChildOid)), lastModified)
     get(oid, createdToteutus.copy(tarjoajat = List(AmmOid, GrandChildOid)))
@@ -320,11 +383,15 @@ class ToteutusSpec extends KoutaIntegrationSpec
   it should "remove toteutuksen tarjoajan oppilaitos from koulutuksen tarjoajat when removed on update" in {
     val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(AmmOid, ChildOid))
     val koulutusOid = put(ophKoulutus, ophSession)
-    val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = GrandChildOid, tarjoajat = List(AmmOid, GrandChildOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]), Seq(AmmOid, GrandChildOid))
-    val oid = put(newToteutus, session)
+    val newToteutus =
+      toteutus(koulutusOid).copy(organisaatioOid = GrandChildOid, tarjoajat = List(AmmOid, GrandChildOid))
+    val session = addTestSession(
+      Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]),
+      Seq(AmmOid, GrandChildOid)
+    )
+    val oid             = put(newToteutus, session)
     val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = userOidForTestSessionId(session))
-    val lastModified = get(oid, createdToteutus)
+    val lastModified    = get(oid, createdToteutus)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(AmmOid, ChildOid)))
     update(createdToteutus.copy(tarjoajat = List(AmmOid)), lastModified)
     get(oid, createdToteutus.copy(tarjoajat = List(AmmOid)))
@@ -333,187 +400,248 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "prevent removal of toteutuksen tarjoajan oppilaitos from koulutuksen tarjoajat when oppilaitos still in use" in {
     val tarjoajaOfOtherOppilaitos = AmmOid
-    val tarjoajaInOtherTotetus = LonelyOid
-    val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(ChildOid, tarjoajaOfOtherOppilaitos))
-    val koulutusOid = put(ophKoulutus, ophSession)
+    val tarjoajaInOtherTotetus    = LonelyOid
+    val ophKoulutus =
+      koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(ChildOid, tarjoajaOfOtherOppilaitos))
+    val koulutusOid   = put(ophKoulutus, ophSession)
     val otherToteutus = toteutus(koulutusOid).copy(organisaatioOid = OphOid, tarjoajat = List(tarjoajaInOtherTotetus))
     put(otherToteutus, ophSession)
-    val newToteutus = toteutus(koulutusOid).copy(organisaatioOid = OphOid, tarjoajat = List(GrandChildOid, EvilGrandChildOid, OtherOid, tarjoajaInOtherTotetus))
-    val oid = put(newToteutus, ophSession)
+    val newToteutus = toteutus(koulutusOid).copy(
+      organisaatioOid = OphOid,
+      tarjoajat = List(GrandChildOid, EvilGrandChildOid, OtherOid, tarjoajaInOtherTotetus)
+    )
+    val oid             = put(newToteutus, ophSession)
     val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = OphUserOid)
-    val lastModified = get(oid, createdToteutus.copy(metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))))
-    get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(ChildOid, OtherOid, tarjoajaOfOtherOppilaitos, tarjoajaInOtherTotetus)))
+    val lastModified = get(
+      oid,
+      createdToteutus.copy(metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true))))
+    )
+    get(
+      koulutusOid,
+      ophKoulutus.copy(
+        oid = Some(KoulutusOid(koulutusOid)),
+        tarjoajat = List(ChildOid, OtherOid, tarjoajaOfOtherOppilaitos, tarjoajaInOtherTotetus)
+      )
+    )
     update(createdToteutus.copy(tarjoajat = List(GrandChildOid)), lastModified)
     get(oid, createdToteutus.copy(tarjoajat = List(GrandChildOid), muokkaaja = TestUserOid))
-    get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(ChildOid, tarjoajaOfOtherOppilaitos, tarjoajaInOtherTotetus)))
+    get(
+      koulutusOid,
+      ophKoulutus.copy(
+        oid = Some(KoulutusOid(koulutusOid)),
+        tarjoajat = List(ChildOid, tarjoajaOfOtherOppilaitos, tarjoajaInOtherTotetus)
+      )
+    )
   }
 
   it should "make all changes to toteutuksen tarjoajien oppilaitokset accordingly in koulutuksen tarjoajat when updated in toteutus" in {
     val untouchedOppilaitosOid = YoOid
-    val newTarjoaja = OrganisaatioOid("1.2.246.562.10.74478323608")
-    val newTarjoaja2 = OrganisaatioOid("1.2.246.562.10.46789068684")
-    val oppilaitosOfTarjoajat = HkiYoOid
-    val ophKoulutus = YoKoulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(LutYoOid, untouchedOppilaitosOid))
+    val newTarjoaja            = OrganisaatioOid("1.2.246.562.10.74478323608")
+    val newTarjoaja2           = OrganisaatioOid("1.2.246.562.10.46789068684")
+    val oppilaitosOfTarjoajat  = HkiYoOid
+    val ophKoulutus =
+      YoKoulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(LutYoOid, untouchedOppilaitosOid))
     val koulutusOid = put(ophKoulutus, ophSession)
-    val newToteutus = JulkaistuYoToteutus.copy(koulutusOid = KoulutusOid(koulutusOid), organisaatioOid = OphOid, tarjoajat = List(LutYoChildOid))
+    val newToteutus = JulkaistuYoToteutus.copy(
+      koulutusOid = KoulutusOid(koulutusOid),
+      organisaatioOid = OphOid,
+      tarjoajat = List(LutYoChildOid)
+    )
     val oid = put(newToteutus, ophSession)
-    val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = OphUserOid, koulutuksetKoodiUri = List("koulutus_371101#1", "koulutus_201000#1"))
-    val lastModified = get(oid, createdToteutus.copy(metadata = Some(YoToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))))
-    get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(LutYoOid, untouchedOppilaitosOid)))
+    val createdToteutus = newToteutus.copy(
+      oid = Some(ToteutusOid(oid)),
+      muokkaaja = OphUserOid,
+      koulutuksetKoodiUri = List("koulutus_371101#1", "koulutus_201000#1")
+    )
+    val lastModified = get(
+      oid,
+      createdToteutus.copy(metadata = Some(YoToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true))))
+    )
+    get(
+      koulutusOid,
+      ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(LutYoOid, untouchedOppilaitosOid))
+    )
     update(createdToteutus.copy(tarjoajat = List(newTarjoaja, newTarjoaja2)), lastModified)
     get(oid, createdToteutus.copy(tarjoajat = List(newTarjoaja, newTarjoaja2), muokkaaja = TestUserOid))
-    get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(untouchedOppilaitosOid, oppilaitosOfTarjoajat)))
+    get(
+      koulutusOid,
+      ophKoulutus.copy(
+        oid = Some(KoulutusOid(koulutusOid)),
+        tarjoajat = List(untouchedOppilaitosOid, oppilaitosOfTarjoajat)
+      )
+    )
   }
 
   it should "remove toteutuksen tarjoajan oppilaitos from koulutuksen tarjoajat when deleting toteutus" in {
     val ophKoulutus = koulutus.copy(organisaatioOid = OphOid, julkinen = true, tarjoajat = List(ChildOid))
     val koulutusOid = put(ophKoulutus, ophSession)
-    val newToteutus = toteutus(koulutusOid).copy(tila = Tallennettu, organisaatioOid = GrandChildOid, tarjoajat = List(GrandChildOid))
-    val session = addTestSession(Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]), Seq(GrandChildOid))
-    val oid = put(newToteutus, session)
+    val newToteutus =
+      toteutus(koulutusOid).copy(tila = Tallennettu, organisaatioOid = GrandChildOid, tarjoajat = List(GrandChildOid))
+    val session = addTestSession(
+      Seq(Role.Toteutus.Crud.asInstanceOf[Role], Role.Koulutus.Read.asInstanceOf[Role]),
+      Seq(GrandChildOid)
+    )
+    val oid             = put(newToteutus, session)
     val createdToteutus = newToteutus.copy(oid = Some(ToteutusOid(oid)), muokkaaja = userOidForTestSessionId(session))
-    val lastModified = get(oid, createdToteutus)
+    val lastModified    = get(oid, createdToteutus)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List(ChildOid)))
     update(createdToteutus.copy(tila = Poistettu), lastModified)
     get(koulutusOid, ophKoulutus.copy(oid = Some(KoulutusOid(koulutusOid)), tarjoajat = List()))
   }
 
   it should "write toteutus update to audit log" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
     MockAuditLogger.clean()
-    update(toteutus(oid, koulutusOid, Arkistoitu).withModified(LocalDateTime.parse("1000-01-01T12:00:00")), lastModified)
+    update(
+      toteutus(oid, koulutusOid, Arkistoitu).withModified(LocalDateTime.parse("1000-01-01T12:00:00")),
+      lastModified
+    )
     MockAuditLogger.findFieldChange("tila", "julkaistu", "arkistoitu", oid, "toteutus_update") shouldBe defined
     MockAuditLogger.find("1000-01-01") should not be defined
   }
 
   it should "return 401 if no session is found" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     post(ToteutusPath, bytes(thisToteutus), Seq(KoutaServlet.IfUnmodifiedSinceHeader -> lastModified)) {
-      status should equal (401)
+      status should equal(401)
     }
   }
 
   it should "allow a user of the toteutus organization to update the toteutus" in {
-    val oid = put(toteutus(koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid)))
+    val oid          = put(toteutus(koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid))
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, expectUpdate = false, ammAndChildSession)
   }
 
   it should "deny a user without access to the toteutus organization" in {
-    val oid = put(toteutus(koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid)))
+    val oid          = put(toteutus(koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(tarjoajat = List(AmmOid, ChildOid))
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, 403, crudSessions(LonelyOid))
   }
 
   it should "deny a user without access to the tarjoaja organizations" in {
-    val oid = put(toteutus(koulutusOid).copy(tarjoajat = List(ChildOid, OtherOid)))
+    val oid          = put(toteutus(koulutusOid).copy(tarjoajat = List(ChildOid, OtherOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(tarjoajat = List(ChildOid, OtherOid))
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, 403, crudSessions(ChildOid))
   }
 
   it should "allow a user of an ancestor organization to update toteutus" in {
-    val oid = put(toteutus(koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(GrandChildOid)))
+    val oid          = put(toteutus(koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(GrandChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(GrandChildOid))
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, expectUpdate = false, crudSessions(ParentOid))
   }
 
   it should "deny a user with only access to a descendant organization" in {
-    val oid = put(toteutus(koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(ChildOid)))
+    val oid          = put(toteutus(koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(ChildOid)))
     val thisToteutus = toteutus(oid, koulutusOid).copy(organisaatioOid = ChildOid, tarjoajat = List(ChildOid))
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, 403, crudSessions(GrandChildOid))
   }
 
   it should "deny a user with the wrong role" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, 403, readSessions(toteutus.organisaatioOid))
   }
 
   it should "allow oph user to update from julkaistu to tallennettu" in {
-    val oid = put(toteutus(koulutusOid))
-    val lastModified = get(oid, toteutus(oid, koulutusOid))
+    val oid             = put(toteutus(koulutusOid))
+    val lastModified    = get(oid, toteutus(oid, koulutusOid))
     val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
     update(updatedToteutus, lastModified, expectUpdate = true, ophSession)
-    get(oid,
-        toteutus(oid, koulutusOid, Tallennettu).copy(muokkaaja = OphUserOid,
-          metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))))
+    get(
+      oid,
+      toteutus(oid, koulutusOid, Tallennettu).copy(
+        muokkaaja = OphUserOid,
+        metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))
+      )
+    )
   }
 
   it should "not allow non oph user to update from julkaistu to tallennettu" in {
-    val oid = put(toteutus(koulutusOid))
-    val lastModified = get(oid, toteutus(oid, koulutusOid))
+    val oid             = put(toteutus(koulutusOid))
+    val lastModified    = get(oid, toteutus(oid, koulutusOid))
     val updatedToteutus = toteutus(oid, koulutusOid, Tallennettu)
     update(updatedToteutus, lastModified, 403, crudSessions(toteutus.organisaatioOid))
   }
 
   it should "allow organisaatioOid change if user had rights to new organisaatio" in {
     var toteutus = JulkaistuYoToteutus.copy(koulutusOid = KoulutusOid(put(YoKoulutus)), organisaatioOid = HkiYoOid)
-    val oid = put(toteutus)
-    toteutus = toteutus.copy(oid = Some(ToteutusOid(oid)), organisaatioOid = HkiYoOid, koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1"))
+    val oid      = put(toteutus)
+    toteutus = toteutus.copy(
+      oid = Some(ToteutusOid(oid)),
+      organisaatioOid = HkiYoOid,
+      koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1")
+    )
     val lastModified = get(oid, toteutus)
     update(toteutus.copy(organisaatioOid = YoOid), lastModified, expectUpdate = true, yliopistotSession)
   }
 
   it should "deny organisaatioOid change if user doesn't have rights to new organisaatio" in {
     var toteutus = JulkaistuYoToteutus.copy(koulutusOid = KoulutusOid(put(YoKoulutus)))
-    val oid = put(toteutus)
-    toteutus = toteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1"))
+    val oid      = put(toteutus)
+    toteutus =
+      toteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_371101#1", "koulutus_201000#1"))
     val lastModified = get(oid, toteutus)
     update(toteutus.copy(organisaatioOid = YoOid), lastModified, 403, crudSessions(YoOid))
   }
 
   it should "deny indexer access" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     update(thisToteutus, lastModified, 403, indexerSession)
   }
 
   it should "fail update if 'x-If-Unmodified-Since' header is missing" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     post(ToteutusPath, bytes(thisToteutus), headers = defaultHeaders) {
-      status should equal (400)
-      body should include (KoutaServlet.IfUnmodifiedSinceHeader)
+      status should equal(400)
+      body should include(KoutaServlet.IfUnmodifiedSinceHeader)
     }
   }
 
   it should "fail update if modified in between get and update" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     Thread.sleep(1500)
     update(toteutus(oid, koulutusOid, Arkistoitu), lastModified)
     post(ToteutusPath, bytes(thisToteutus), headersIfUnmodifiedSince(lastModified)) {
-      status should equal (409)
+      status should equal(409)
     }
   }
 
   it should "update toteutuksen nimi, metadata ja tarjoajat" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val thisToteutus = toteutus(oid, koulutusOid)
     val lastModified = get(oid, thisToteutus)
     val uusiToteutus = thisToteutus.copy(
       nimi = Map(Fi -> "kiva nimi", Sv -> "nimi sv"),
       metadata = Some(ammMetatieto.copy(kuvaus = Map(Fi -> "kuvaus", Sv -> "kuvaus sv"))),
       tarjoajat = List(LonelyOid, OtherOid, AmmOid),
-      _enrichedData = Some(ToteutusEnrichedData(esitysnimi = Map(Fi -> "kiva nimi", Sv -> "nimi sv"), muokkaajanNimi = Some("Testi Muokkaaja")))
+      _enrichedData = Some(
+        ToteutusEnrichedData(
+          esitysnimi = Map(Fi -> "kiva nimi", Sv -> "nimi sv"),
+          muokkaajanNimi = Some("Testi Muokkaaja")
+        )
+      )
     )
     update(uusiToteutus, lastModified, expectUpdate = true)
     get(oid, uusiToteutus)
   }
 
   it should "delete all tarjoajat and read last modified from history" in {
-    val oid = put(toteutus(koulutusOid).copy(tila = Tallennettu))
+    val oid          = put(toteutus(koulutusOid).copy(tila = Tallennettu))
     val thisToteutus = toteutus(oid, koulutusOid).copy(tila = Tallennettu)
     val lastModified = get(oid, thisToteutus)
     Thread.sleep(1500)
@@ -522,7 +650,7 @@ class ToteutusSpec extends KoutaIntegrationSpec
     get(oid, uusiToteutus) should not equal lastModified
   }
 
-  it should "set last_modified right for old koulutukset after database migration" in {
+  it should "set last_modified right for old toteutukset after database migration" in {
     db.clean()
     db.migrate("107")
     addDefaultSession()
@@ -560,7 +688,10 @@ class ToteutusSpec extends KoutaIntegrationSpec
   it should "add right amount of rows to history tables" in {
     resetTableHistory("toteutukset")
     resetTableHistory("toteutusten_tarjoajat")
-    val baseToteutus = toteutus(koulutusOid).copy(muokkaaja = OphUserOid, metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true))))
+    val baseToteutus = toteutus(koulutusOid).copy(
+      muokkaaja = OphUserOid,
+      metadata = Some(AmmToteutuksenMetatieto.copy(isMuokkaajaOphVirkailija = Some(true)))
+    )
 
     val oid          = put(baseToteutus, ophSession)
     val lastModified = get(oid, baseToteutus.copy(oid = Some(ToteutusOid(oid))))
@@ -581,36 +712,53 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   it should "store and update unfinished toteutus" in {
-    val unfinishedToteutus = Toteutus(muokkaaja = TestUserOid, koulutusOid = KoulutusOid(koulutusOid),
-      organisaatioOid = ChildOid, modified = None, kielivalinta = Seq(Fi), nimi = Map(Fi -> "toteutus"))
+    val unfinishedToteutus = Toteutus(
+      muokkaaja = TestUserOid,
+      koulutusOid = KoulutusOid(koulutusOid),
+      organisaatioOid = ChildOid,
+      modified = None,
+      kielivalinta = Seq(Fi),
+      nimi = Map(Fi -> "toteutus")
+    )
     val oid = put(unfinishedToteutus)
-    val lastModified = get(oid, unfinishedToteutus.copy(
-      oid = Some(ToteutusOid(oid)),
-      koulutuksetKoodiUri = Seq("koulutus_371101#1"),
-      _enrichedData = Some(ToteutusEnrichedData(esitysnimi = Map(Fi -> "toteutus"), muokkaajanNimi = Some("Testi Muokkaaja")))))
+    val lastModified = get(
+      oid,
+      unfinishedToteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        koulutuksetKoodiUri = Seq("koulutus_371101#1"),
+        _enrichedData =
+          Some(ToteutusEnrichedData(esitysnimi = Map(Fi -> "toteutus"), muokkaajanNimi = Some("Testi Muokkaaja")))
+      )
+    )
     val newKoulutusOid = put(koulutus, ophSession)
     val newUnfinishedToteutus = unfinishedToteutus.copy(
       oid = Some(ToteutusOid(oid)),
       koulutusOid = KoulutusOid(newKoulutusOid),
       koulutuksetKoodiUri = Seq("koulutus_371101#1"),
-      _enrichedData = Some(ToteutusEnrichedData(esitysnimi = Map(Fi -> "toteutus"), muokkaajanNimi = Some("Testi Muokkaaja"))))
+      _enrichedData =
+        Some(ToteutusEnrichedData(esitysnimi = Map(Fi -> "toteutus"), muokkaajanNimi = Some("Testi Muokkaaja")))
+    )
     update(newUnfinishedToteutus, lastModified)
     get(oid, newUnfinishedToteutus)
   }
 
   it should "validate updated toteutus" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
-    post(ToteutusPath, bytes(toteutus(oid, koulutusOid).copy(tarjoajat = List("katkarapu").map(OrganisaatioOid))), headersIfUnmodifiedSince(lastModified)) {
+    post(
+      ToteutusPath,
+      bytes(toteutus(oid, koulutusOid).copy(tarjoajat = List("katkarapu").map(OrganisaatioOid))),
+      headersIfUnmodifiedSince(lastModified)
+    ) {
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(validationMsg("katkarapu"), "tarjoajat[0]"))
+      body should equal(validationErrorBody(validationMsg("katkarapu"), "tarjoajat[0]"))
     }
   }
 
   it should "copy a temporary image to a permanent location while updating the toteutus" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
 
     saveLocalPng("temp/image.png")
@@ -623,9 +771,10 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }
 
   it should "not touch an image that's not in the temporary location" in {
-    val oid = put(toteutus(koulutusOid))
+    val oid          = put(toteutus(koulutusOid))
     val lastModified = get(oid, toteutus(oid, koulutusOid))
-    val toteutusWithImage = toteutus(oid, koulutusOid).withTeemakuva(Some(s"$PublicImageServer/kuvapankki-tai-joku/image.png"))
+    val toteutusWithImage =
+      toteutus(oid, koulutusOid).withTeemakuva(Some(s"$PublicImageServer/kuvapankki-tai-joku/image.png"))
 
     update(toteutusWithImage, lastModified)
 
@@ -685,24 +834,36 @@ class ToteutusSpec extends KoutaIntegrationSpec
   }"""
 
   it should "fail to extract toteutus from JSON of incorrect form" in {
-    an [org.json4s.MappingException] shouldBe thrownBy(ToteutusJsonMethods.extractJsonString(incorrectJson))
+    an[org.json4s.MappingException] shouldBe thrownBy(ToteutusJsonMethods.extractJsonString(incorrectJson))
   }
 
   "When tutkintoon johtamaton, toteutus servlet" should "create, get and update ammatillinen osaamisala toteutus" in {
-    val sorakuvausId = put(sorakuvaus)
+    val sorakuvausId     = put(sorakuvaus)
     val ammOaKoulutusOid = put(TestData.AmmOsaamisalaKoulutus.copy(tila = Julkaistu))
-    val ammOaToteutus = TestData.AmmOsaamisalaToteutus.copy(koulutusOid = KoulutusOid(ammOaKoulutusOid), sorakuvausId = Some(sorakuvausId), tila = Tallennettu)
+    val ammOaToteutus = TestData.AmmOsaamisalaToteutus.copy(
+      koulutusOid = KoulutusOid(ammOaKoulutusOid),
+      sorakuvausId = Some(sorakuvausId),
+      tila = Tallennettu
+    )
     val oid = put(ammOaToteutus)
-    val lastModified = get(oid, ammOaToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_371101#1")))
+    val lastModified =
+      get(oid, ammOaToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_371101#1")))
     update(ammOaToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
-    get(oid, ammOaToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq("koulutus_371101#1")))
+    get(
+      oid,
+      ammOaToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq("koulutus_371101#1"))
+    )
   }
 
   it should "create, get and update ammatillinen tutkinnon osa toteutus" in {
-    val sorakuvausId = put(sorakuvaus)
+    val sorakuvausId     = put(sorakuvaus)
     val ammToKoulutusOid = put(TestData.AmmTutkinnonOsaKoulutus.copy(tila = Julkaistu))
-    val ammToToteutus = TestData.AmmTutkinnonOsaToteutus.copy(koulutusOid = KoulutusOid(ammToKoulutusOid), sorakuvausId = Some(sorakuvausId), tila = Tallennettu)
-    val oid = put(ammToToteutus)
+    val ammToToteutus = TestData.AmmTutkinnonOsaToteutus.copy(
+      koulutusOid = KoulutusOid(ammToKoulutusOid),
+      sorakuvausId = Some(sorakuvausId),
+      tila = Tallennettu
+    )
+    val oid          = put(ammToToteutus)
     val lastModified = get(oid, ammToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
     update(ammToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
     get(oid, ammToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq()))
@@ -710,47 +871,77 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "create, get and update muu ammatillinen toteutus" in {
     val ammMuuKoulutusOid = put(TestData.AmmMuuKoulutus.copy(tila = Julkaistu), ophSession)
-    val ammMuuToteutus = TestData.AmmMuuToteutus.copy(koulutusOid = KoulutusOid(ammMuuKoulutusOid), tila = Tallennettu)
-    val oid = put(ammMuuToteutus)
-    val lastModified = get(oid, ammMuuToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
+    val ammMuuToteutus    = TestData.AmmMuuToteutus.copy(koulutusOid = KoulutusOid(ammMuuKoulutusOid), tila = Tallennettu)
+    val oid               = put(ammMuuToteutus)
+    val lastModified      = get(oid, ammMuuToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
     update(ammMuuToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
     get(oid, ammMuuToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq()))
   }
 
   it should "create, get and update lukio toteutus" in {
-    val _enrichedData = Some(ToteutusEnrichedData(esitysnimi = Map(
-      Fi -> s"""toteutuslomake.lukionYleislinjaNimiOsa fi, 40 yleiset.opintopistetta fi
-        |nimi, 40 yleiset.opintopistetta fi
-        |nimi, 40 yleiset.opintopistetta fi""".stripMargin,
-      Sv -> s"""toteutuslomake.lukionYleislinjaNimiOsa sv, 40 yleiset.opintopistetta sv
-        |nimi sv, 40 yleiset.opintopistetta sv
-        |nimi sv, 40 yleiset.opintopistetta sv""".stripMargin,
-      ),
-      muokkaajanNimi = Some("Testi Muokkaaja")))
+    val _enrichedData = Some(
+      ToteutusEnrichedData(
+        esitysnimi = Map(
+          Fi -> s"""toteutuslomake.lukionYleislinjaNimiOsa fi, 40 yleiset.opintopistetta fi
+                   |nimi, 40 yleiset.opintopistetta fi
+                   |nimi, 40 yleiset.opintopistetta fi""".stripMargin,
+          Sv -> s"""toteutuslomake.lukionYleislinjaNimiOsa sv, 40 yleiset.opintopistetta sv
+                   |nimi sv, 40 yleiset.opintopistetta sv
+                   |nimi sv, 40 yleiset.opintopistetta sv""".stripMargin
+        ),
+        muokkaajanNimi = Some("Testi Muokkaaja")
+      )
+    )
     val lukioToKoulutusOid = put(TestData.LukioKoulutus.copy(tila = Julkaistu), ophSession)
-    val lukioToToteutus = TestData.LukioToteutus.copy(koulutusOid = KoulutusOid(lukioToKoulutusOid), nimi = Map(), tila = Tallennettu, _enrichedData = _enrichedData)
-    val oid = put(lukioToToteutus)
-    val lastModified = get(oid, lukioToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_301101#1")))
-    update(lukioToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
-    get(oid, lukioToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq("koulutus_301101#1"),
+    val lukioToToteutus = TestData.LukioToteutus.copy(
+      koulutusOid = KoulutusOid(lukioToKoulutusOid),
+      nimi = Map(),
+      tila = Tallennettu,
       _enrichedData = _enrichedData
-      ))
+    )
+    val oid = put(lukioToToteutus)
+    val lastModified =
+      get(oid, lukioToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_301101#1")))
+    update(lukioToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
+    get(
+      oid,
+      lukioToToteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        tila = Julkaistu,
+        koulutuksetKoodiUri = Seq("koulutus_301101#1"),
+        _enrichedData = _enrichedData
+      )
+    )
   }
 
   it should "create, get and update tuva toteutus" in {
-    val tuvaToKoulutusOid = put(TestData.TuvaKoulutus.copy(tila = Julkaistu), ophSession)
-    val tuvaToToteutus = TestData.TuvaToteutus.copy(koulutusOid = KoulutusOid(tuvaToKoulutusOid), tila = Tallennettu)
-    val oid = put(tuvaToToteutus)
-    val lastModified = get(oid, tuvaToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
+    val tuvaToKoulutusOid                = put(TestData.TuvaKoulutus.copy(tila = Julkaistu), ophSession)
+    val tuvaToToteutus                   = TestData.TuvaToteutus.copy(koulutusOid = KoulutusOid(tuvaToKoulutusOid), tila = Tallennettu)
+    val oid                              = put(tuvaToToteutus)
+    val lastModified                     = get(oid, tuvaToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
     val modifiedTuvaToteutuksenMetatieto = Some(TuvaToteutuksenMetatieto.copy(hasJotpaRahoitus = Some(true)))
-    update(tuvaToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, metadata = modifiedTuvaToteutuksenMetatieto), lastModified)
-    get(oid, tuvaToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, metadata = Some(TuvaToteutuksenMetatieto.copy(hasJotpaRahoitus = Some(true))), koulutuksetKoodiUri = Seq()))
+    update(
+      tuvaToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, metadata = modifiedTuvaToteutuksenMetatieto),
+      lastModified
+    )
+    get(
+      oid,
+      tuvaToToteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        tila = Julkaistu,
+        metadata = Some(TuvaToteutuksenMetatieto.copy(hasJotpaRahoitus = Some(true))),
+        koulutuksetKoodiUri = Seq()
+      )
+    )
   }
 
   it should "create, get and update kk-opintojakson toteutus" in {
     val kkOpintojaksoKoulutusOid = put(TestData.KkOpintojaksoKoulutus.copy(tila = Julkaistu), ophSession)
-    val kkOpintojaksoToteutus = TestData.JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(kkOpintojaksoKoulutusOid), tila = Tallennettu)
-    val oid = put(kkOpintojaksoToteutus)
+    val kkOpintojaksoToteutus = TestData.JulkaistuKkOpintojaksoToteutus.copy(
+      koulutusOid = KoulutusOid(kkOpintojaksoKoulutusOid),
+      tila = Tallennettu
+    )
+    val oid          = put(kkOpintojaksoToteutus)
     val lastModified = get(oid, kkOpintojaksoToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
     update(kkOpintojaksoToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
     get(oid, kkOpintojaksoToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq()))
@@ -758,24 +949,57 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "create, get and update kk-opintokokonaisuus toteutus" in {
     val kkOpintojaksoKoulutusOid = put(TestData.KkOpintojaksoKoulutus.copy(tila = Julkaistu), ophSession)
-    val kkOpintojaksoToteutus = put(TestData.JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(kkOpintojaksoKoulutusOid)), ophSession)
+    val kkOpintojaksoToteutus =
+      put(TestData.JulkaistuKkOpintojaksoToteutus.copy(koulutusOid = KoulutusOid(kkOpintojaksoKoulutusOid)), ophSession)
     val kkOpintokokonaisuusKoulutusOid = put(TestData.KkOpintokokonaisuusKoulutus.copy(tila = Julkaistu), ophSession)
     val kkOpintokokonaisuusToteutus = TestData.JulkaistuKkOpintokokonaisuusToteutus.copy(
       koulutusOid = KoulutusOid(kkOpintokokonaisuusKoulutusOid),
       tila = Tallennettu,
-      metadata = Some(TestData.KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(kkOpintojaksoToteutus)))))
-    val oid = put(kkOpintokokonaisuusToteutus.copy(metadata = Some(TestData.KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot = Seq(ToteutusOid(kkOpintojaksoToteutus))))))
-    val lastModified = get(oid, kkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
+      metadata = Some(
+        TestData.KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot =
+          Seq(ToteutusOid(kkOpintojaksoToteutus))
+        )
+      )
+    )
+    val oid = put(
+      kkOpintokokonaisuusToteutus.copy(metadata =
+        Some(
+          TestData.KkOpintokokonaisuusToteutuksenMetatieto.copy(liitetytOpintojaksot =
+            Seq(ToteutusOid(kkOpintojaksoToteutus))
+          )
+        )
+      )
+    )
+    val lastModified =
+      get(oid, kkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq()))
     update(kkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
-    get(oid, kkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq()))
+    get(
+      oid,
+      kkOpintokokonaisuusToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq())
+    )
   }
 
   "Toteutus nimi" should "be copied from koulutus for certain koulutustyypit" in {
-    var toteutus = AmmOsaamisalaToteutus.copy(koulutusOid = KoulutusOid(put(AmmOsaamisalaKoulutus)), nimi = Map(), koulutuksetKoodiUri = Seq())
+    var toteutus = AmmOsaamisalaToteutus.copy(
+      koulutusOid = KoulutusOid(put(AmmOsaamisalaKoulutus)),
+      nimi = Map(),
+      koulutuksetKoodiUri = Seq()
+    )
     var oid = put(toteutus)
-    get(oid, toteutus.copy(oid = Some(ToteutusOid(oid)), nimi = AmmOsaamisalaKoulutus.nimi, koulutuksetKoodiUri = Seq("koulutus_371101#1")))
+    get(
+      oid,
+      toteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        nimi = AmmOsaamisalaKoulutus.nimi,
+        koulutuksetKoodiUri = Seq("koulutus_371101#1")
+      )
+    )
 
-    toteutus = AmmTutkinnonOsaToteutus.copy(koulutusOid = KoulutusOid(put(AmmTutkinnonOsaKoulutus)), nimi = Map(), koulutuksetKoodiUri = Seq())
+    toteutus = AmmTutkinnonOsaToteutus.copy(
+      koulutusOid = KoulutusOid(put(AmmTutkinnonOsaKoulutus)),
+      nimi = Map(),
+      koulutuksetKoodiUri = Seq()
+    )
     oid = put(toteutus)
     get(oid, toteutus.copy(oid = Some(ToteutusOid(oid)), nimi = AmmTutkinnonOsaKoulutus.nimi))
 
@@ -787,24 +1011,34 @@ class ToteutusSpec extends KoutaIntegrationSpec
     oid = put(toteutus)
     get(oid, toteutus.copy(oid = Some(ToteutusOid(oid)), nimi = TuvaKoulutus.nimi, koulutuksetKoodiUri = Seq()))
 
-    toteutus = VapaaSivistystyoOpistovuosiToteutus.copy(koulutusOid = KoulutusOid(put(VapaaSivistystyoOpistovuosiKoulutus, ophSession)), nimi = Map())
+    toteutus = VapaaSivistystyoOpistovuosiToteutus.copy(
+      koulutusOid = KoulutusOid(put(VapaaSivistystyoOpistovuosiKoulutus, ophSession)),
+      nimi = Map()
+    )
     oid = put(toteutus)
-    get(oid, toteutus.copy(oid = Some(ToteutusOid(oid)), nimi = VapaaSivistystyoOpistovuosiToteutus.nimi, koulutuksetKoodiUri = Seq()))
+    get(
+      oid,
+      toteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        nimi = VapaaSivistystyoOpistovuosiToteutus.nimi,
+        koulutuksetKoodiUri = Seq()
+      )
+    )
   }
 
   "Copy toteutukset" should "make a copy of a julkaistu toteutus and store it as tallennettu" in {
     val julkaistuToteutusOid = put(toteutus(koulutusOid))
-    val toteutukset = List(julkaistuToteutusOid)
-    val copyResults = put(toteutukset)
-    val copyOid = copyResults.head.created.toteutusOid
+    val toteutukset          = List(julkaistuToteutusOid)
+    val copyResults          = put(toteutukset)
+    val copyOid              = copyResults.head.created.toteutusOid
     get(copyOid.get.toString, toteutus(koulutusOid).copy(oid = Some(copyOid.get), tila = Tallennettu))
   }
 
   it should "copy two julkaistu toteutus and store them as tallennettu" in {
     val julkaistuToteutusOid1 = put(toteutus(koulutusOid))
     val julkaistuToteutusOid2 = put(toteutus(koulutusOid))
-    val toteutukset = List(julkaistuToteutusOid1, julkaistuToteutusOid2)
-    val copyResults = put(toteutukset)
+    val toteutukset           = List(julkaistuToteutusOid1, julkaistuToteutusOid2)
+    val copyResults           = put(toteutukset)
     for (result <- copyResults) {
       val copyOid = result.created.toteutusOid.get
       get(copyOid.toString, toteutus(koulutusOid).copy(oid = Some(copyOid), tila = Tallennettu))
@@ -821,10 +1055,19 @@ class ToteutusSpec extends KoutaIntegrationSpec
 
   it should "create, get and update aikuisten perusopetus -toteutus" in {
     val aiPeToKoulutusOid = put(TestData.AikuistenPerusopetusKoulutus.copy(tila = Julkaistu), ophSession)
-    val aiPeToToteutus = TestData.AikuistenPerusopetusToteutus.copy(koulutusOid = KoulutusOid(aiPeToKoulutusOid), tila = Tallennettu)
+    val aiPeToToteutus =
+      TestData.AikuistenPerusopetusToteutus.copy(koulutusOid = KoulutusOid(aiPeToKoulutusOid), tila = Tallennettu)
     val oid = put(aiPeToToteutus)
-    val lastModified = get(oid, aiPeToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_201101#12")))
+    val lastModified =
+      get(oid, aiPeToToteutus.copy(oid = Some(ToteutusOid(oid)), koulutuksetKoodiUri = Seq("koulutus_201101#12")))
     update(aiPeToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu), lastModified)
-    get(oid, aiPeToToteutus.copy(oid = Some(ToteutusOid(oid)), tila = Julkaistu, koulutuksetKoodiUri = Seq("koulutus_201101#12")))
+    get(
+      oid,
+      aiPeToToteutus.copy(
+        oid = Some(ToteutusOid(oid)),
+        tila = Julkaistu,
+        koulutuksetKoodiUri = Seq("koulutus_201101#12")
+      )
+    )
   }
 }

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ToteutusSpec.scala
@@ -662,7 +662,7 @@ class ToteutusSpec
     }
     val lastModified = get(oid, thisToteutus)
     val muokattuToteutus = thisToteutus.copy(
-      tarjoajat = List(LonelyOid, OtherOid)
+      tarjoajat = List(AmmOid)
     )
     update(muokattuToteutus, lastModified, expectUpdate = true, sessionId = ophSession)
     assert(readToteutusMuokkaaja(oid) == OphUserOid.toString)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/ValintaperusteSpec.scala
@@ -26,8 +26,8 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
 
   "Get valintaperuste by id" should "return 404 if valintaperuste not found" in {
     get(s"/valintaperuste/${UUID.randomUUID()}", headers = defaultHeaders) {
-      status should equal (404)
-      body should include ("Unknown valintaperuste id")
+      status should equal(404)
+      body should include("Unknown valintaperuste id")
     }
   }
 
@@ -112,7 +112,7 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
 
   it should "return 401 if no session is found" in {
     put(s"$ValintaperustePath", bytes(valintaperuste)) {
-      status should equal (401)
+      status should equal(401)
     }
   }
 
@@ -149,27 +149,27 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(validationMsg("saippua"), "organisaatioOid"))
+      body should equal(validationErrorBody(validationMsg("saippua"), "organisaatioOid"))
     }
   }
 
   "Update valintaperuste" should "update valintaperuste" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(getIds(valintaperuste(id, Arkistoitu)), lastModified)
     get(id, valintaperuste(id, Arkistoitu))
   }
 
   it should "read muokkaaja from the session" in {
-    val id = put(valintaperuste, crudSessions(ChildOid))
-    val userOid = userOidForTestSessionId(crudSessions(ChildOid))
+    val id           = put(valintaperuste, crudSessions(ChildOid))
+    val userOid      = userOidForTestSessionId(crudSessions(ChildOid))
     val lastModified = get(id, valintaperuste(id).copy(muokkaaja = userOid))
     update(getIds(valintaperuste(id, Arkistoitu).copy(muokkaaja = userOid)), lastModified)
     get(id, valintaperuste(id, Arkistoitu).copy(muokkaaja = testUser.oid))
   }
 
   it should "write valintaperuste update to audit log" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     MockAuditLogger.clean()
     update(getIds(valintaperuste(id, Arkistoitu)), lastModified)
@@ -178,54 +178,59 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
   }
 
   it should "not update valintaperuste" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     MockAuditLogger.clean()
     update(tallennettuValintaperuste(id), lastModified, expectUpdate = false)
     MockAuditLogger.logs shouldBe empty
-    get(id, valintaperuste(id)) should equal (lastModified)
+    get(id, valintaperuste(id)) should equal(lastModified)
   }
 
   it should "return 401 if no session is found" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     post(ValintaperustePath, bytes(valintaperuste(id)), Seq(KoutaServlet.IfUnmodifiedSinceHeader -> lastModified)) {
-      status should equal (401)
+      status should equal(401)
     }
   }
 
   it should "allow a user of the valintaperuste organization to update the valintaperuste" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
-    update(tallennettuValintaperuste(id), lastModified, expectUpdate = false, crudSessions(valintaperuste.organisaatioOid))
+    update(
+      tallennettuValintaperuste(id),
+      lastModified,
+      expectUpdate = false,
+      crudSessions(valintaperuste.organisaatioOid)
+    )
   }
 
   it should "deny a user without access to the valintaperuste organization" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(tallennettuValintaperuste(id), lastModified, 403, crudSessions(LonelyOid))
   }
 
   it should "allow a user of an ancestor organization to update valintaperuste" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(tallennettuValintaperuste(id), lastModified, expectUpdate = false, crudSessions(ParentOid))
   }
 
   it should "deny a user with only access to a descendant organization" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(tallennettuValintaperuste(id), lastModified, 403, crudSessions(GrandChildOid))
   }
 
   it should "deny a user with the wrong role" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(tallennettuValintaperuste(id), lastModified, 403, readSessions(valintaperuste.organisaatioOid))
   }
 
   it should "deny indexer access" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(tallennettuValintaperuste(id), lastModified, 403, indexerSession)
   }
@@ -233,45 +238,78 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
   it should "fail update if 'x-If-Unmodified-Since' header is missing" in {
     val id = put(valintaperuste)
     post(ValintaperustePath, bytes(valintaperuste(id)), defaultHeaders) {
-      status should equal (400)
-      body should include (KoutaServlet.IfUnmodifiedSinceHeader)
+      status should equal(400)
+      body should include(KoutaServlet.IfUnmodifiedSinceHeader)
     }
   }
 
   it should "fail update if modified in between get and update" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     Thread.sleep(1500)
     update(getIds(valintaperuste(id, Arkistoitu)), lastModified)
     post(ValintaperustePath, bytes(valintaperuste(id)), headersIfUnmodifiedSince(lastModified)) {
-      status should equal (409)
+      status should equal(409)
     }
   }
 
   it should "update valintakokeet" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     val uusiValintaperuste = valintaperuste(id).copy(
       nimi = Map(Fi -> "kiva nimi", Sv -> "nimi sv"),
-      valintakokeet = List(TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_42#2"))))
+      valintakokeet = List(TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_42#2")))
+    )
     update(getIds(uusiValintaperuste), lastModified, expectUpdate = true)
     get(id, uusiValintaperuste)
   }
 
   it should "put, update and delete valintakokeet correctly" in {
     val valintaperusteWithValintakokeet = valintaperuste.copy(
-      valintakokeet = Seq(TestData.Valintakoe1, TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_66#6")))
+      valintakokeet =
+        Seq(TestData.Valintakoe1, TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_66#6")))
     )
-    val id = put(valintaperusteWithValintakokeet)
-    val lastModified = get(id, getIds(valintaperusteWithValintakokeet.copy(id = Some(id))))
+    val id            = put(valintaperusteWithValintakokeet)
+    val lastModified  = get(id, getIds(valintaperusteWithValintakokeet.copy(id = Some(id))))
     val newValintakoe = TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_57#2"))
-    val updateValintakoe = getIds(valintaperuste(id)).valintakokeet.head.copy(nimi = Map(Fi -> "Uusi nimi", Sv -> "Uusi nimi på svenska"))
+    val updateValintakoe =
+      getIds(valintaperuste(id)).valintakokeet.head.copy(nimi = Map(Fi -> "Uusi nimi", Sv -> "Uusi nimi på svenska"))
     update(valintaperuste(id).copy(valintakokeet = Seq(newValintakoe, updateValintakoe)), lastModified)
     get(id, getIds(valintaperuste(id).copy(valintakokeet = Seq(newValintakoe, updateValintakoe))))
   }
 
+  it should "update muokkaaja of valintaperuste on put, update and delete for valintakokeet" in {
+    val valintaperusteWithValintakokeet = valintaperuste.copy(
+      valintakokeet =
+        Seq(TestData.Valintakoe1, TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_66#6")))
+    )
+    val id = put(valintaperusteWithValintakokeet)
+    assert(readValintaperusteMuokkaaja(id.toString) == TestUserOid.toString)
+    val lastModified  = get(id, getIds(valintaperusteWithValintakokeet.copy(id = Some(id))))
+    val newValintakoe = TestData.Valintakoe1.copy(tyyppiKoodiUri = Some("valintakokeentyyppi_57#2"))
+    val updateValintakoe =
+      getIds(valintaperuste(id)).valintakokeet.head.copy(nimi = Map(Fi -> "Uusi nimi", Sv -> "Uusi nimi på svenska"))
+    update(
+      valintaperuste(id).copy(valintakokeet = Seq(newValintakoe, updateValintakoe)),
+      lastModified,
+      expectUpdate = true,
+      ophSession
+    )
+    assert(readValintaperusteMuokkaaja(id.toString) == OphUserOid.toString)
+    get(
+      id,
+      getIds(
+        valintaperuste(id).copy(
+          muokkaaja = OphUserOid,
+          valintakokeet = Seq(newValintakoe, updateValintakoe),
+          metadata = Some(TestData.AmmValintaperusteMetadata.copy(isMuokkaajaOphVirkailija = Some(true)))
+        )
+      )
+    )
+  }
+
   it should "delete all valintakokeet and read last modified from history" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     Thread.sleep(1500)
     val uusiValintaperuste = getIds(valintaperuste(id).copy(valintakokeet = List()))
@@ -283,8 +321,8 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
     resetTableHistory("valintaperusteet")
     resetTableHistory("valintaperusteiden_valintakokeet")
 
-    val id           = put(valintaperuste)
-    val lastModified = get(id, valintaperuste(id))
+    val id                 = put(valintaperuste)
+    val lastModified       = get(id, valintaperuste(id))
     val uusiValintaperuste = getIds(valintaperuste(id).copy(valintakokeet = List()))
     update(uusiValintaperuste, lastModified, expectUpdate = true)
 
@@ -293,46 +331,57 @@ class ValintaperusteSpec extends KoutaIntegrationSpec with ValintaperusteFixture
   }
 
   it should "store and update unfinished valintaperuste" in {
-    val unfinishedValintaperuste = MinYoValintaperuste
-    val id = put(unfinishedValintaperuste)
-    val lastModified = get(id, unfinishedValintaperuste.copy(id = Some(id)))
+    val unfinishedValintaperuste    = MinYoValintaperuste
+    val id                          = put(unfinishedValintaperuste)
+    val lastModified                = get(id, unfinishedValintaperuste.copy(id = Some(id)))
     val newUnfinishedValintaperuste = unfinishedValintaperuste.copy(id = Some(id), organisaatioOid = LonelyOid)
     update(newUnfinishedValintaperuste, lastModified)
     get(id, newUnfinishedValintaperuste)
   }
 
   it should "validate updated valintaperuste" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
-    post(ValintaperustePath, bytes(valintaperuste(id).copy(organisaatioOid = OrganisaatioOid("saippua"))), headersIfUnmodifiedSince(lastModified)) {
+    post(
+      ValintaperustePath,
+      bytes(valintaperuste(id).copy(organisaatioOid = OrganisaatioOid("saippua"))),
+      headersIfUnmodifiedSince(lastModified)
+    ) {
       withClue(body) {
         status should equal(400)
       }
-      body should equal (validationErrorBody(validationMsg("saippua"), "organisaatioOid"))
+      body should equal(validationErrorBody(validationMsg("saippua"), "organisaatioOid"))
     }
   }
 
   it should "allow oph user to update from julkaistu to tallennettu" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(valintaperuste(id).copy(tila = Tallennettu), lastModified, expectUpdate = true, ophSession)
-    get(id, valintaperuste(id).copy(tila = Tallennettu, muokkaaja = OphUserOid, metadata = Some(TestData.AmmValintaperusteMetadata.copy(isMuokkaajaOphVirkailija = Some(true)))))
+    get(
+      id,
+      valintaperuste(id).copy(
+        tila = Tallennettu,
+        muokkaaja = OphUserOid,
+        metadata = Some(TestData.AmmValintaperusteMetadata.copy(isMuokkaajaOphVirkailija = Some(true)))
+      )
+    )
   }
 
   it should "not allow non oph user to update from julkaistu to tallennettu" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(valintaperuste(id).copy(tila = Tallennettu), lastModified, 403, crudSessions(valintaperuste.organisaatioOid))
   }
 
   it should "allow organisaatioOid change if user had rights to new organisaatio" in {
-    val id = put(valintaperuste.copy(organisaatioOid = HkiYoOid))
+    val id           = put(valintaperuste.copy(organisaatioOid = HkiYoOid))
     val lastModified = get(id, valintaperuste(id).copy(organisaatioOid = HkiYoOid))
     update(valintaperuste(id).copy(organisaatioOid = YoOid), lastModified, expectUpdate = true, yliopistotSession)
   }
 
   it should "fail organisaatioOid change if user doesn't have rights to new organisaatio" in {
-    val id = put(valintaperuste)
+    val id           = put(valintaperuste)
     val lastModified = get(id, valintaperuste(id))
     update(valintaperuste(id).copy(organisaatioOid = YoOid), lastModified, 403, crudSessions(YoOid))
   }

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/DatabaseFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/DatabaseFixture.scala
@@ -53,9 +53,16 @@ trait DatabaseFixture {
     db.runBlocking(sqlu"""delete from ammattinimikkeet""")
   }
 
+  def getStringColumnValue(tableName: String, column: String, idKey: String = "", id: String = ""): String =
+    db.runBlocking(
+      sql"""select #${column} from #${tableName} where #${s"$idKey = '$id'"};""".as[String].head
+    )
+
   // Slick lisää jostain syystä SQL-kyselyyn loppuun sulut, jos ei laita "where true"
   def getTableHistorySize(tableName: String, idKey: String = "", id: String = ""): Int = db.runBlocking(
-    sql"""select count(*) from #${tableName}_history where #${if (id.nonEmpty) s"$idKey = '$id'" else "true"};""".as[Int].head
+    sql"""select count(*) from #${tableName}_history where #${if (id.nonEmpty) s"$idKey = '$id'" else "true"};"""
+      .as[Int]
+      .head
   )
 
   def resetTableHistory(tableName: String) = {

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/HakukohdeFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/HakukohdeFixture.scala
@@ -11,7 +11,16 @@ import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.{AccessControlSpec, KoutaIntegrationSpec}
 import fi.oph.kouta.mocks.{MockAuditLogger, MockS3ImageService}
 import fi.oph.kouta.repository.{HakuDAO, HakukohdeDAO, KoulutusDAO, SQLHelpers, SorakuvausDAO, ToteutusDAO}
-import fi.oph.kouta.service.{HakukohdeCopyResultObject, HakukohdeService, HakukohdeServiceValidation, HakukohdeTilaChangeResultObject, KeywordService, OrganisaatioServiceImpl, ToteutusService, ToteutusServiceValidation}
+import fi.oph.kouta.service.{
+  HakukohdeCopyResultObject,
+  HakukohdeService,
+  HakukohdeServiceValidation,
+  HakukohdeTilaChangeResultObject,
+  KeywordService,
+  OrganisaatioServiceImpl,
+  ToteutusService,
+  ToteutusServiceValidation
+}
 import fi.oph.kouta.servlet.HakukohdeServlet
 import fi.oph.kouta.util.TimeUtils
 import org.scalactic.Equality
@@ -20,8 +29,8 @@ import slick.jdbc.PostgresProfile.api._
 trait HakukohdeFixture extends SQLHelpers with AccessControlSpec with ToteutusFixture {
   this: KoutaIntegrationSpec with KoulutusFixture =>
 
-  val HakukohdePath     = "/hakukohde"
-  val HakukohdeCopyPath = s"/hakukohde/copy/"
+  val HakukohdePath           = "/hakukohde"
+  val HakukohdeCopyPath       = s"/hakukohde/copy/"
   val HakukohdeChangeTilaPath = s"/hakukohde/tila/"
 
   def hakukohdeService: HakukohdeService = {
@@ -136,7 +145,13 @@ trait HakukohdeFixture extends SQLHelpers with AccessControlSpec with ToteutusFi
       )
     )
 
-  def tallennettuLukioHakukohde(oid: String, toteutusOid: String, hakuOid: String, nimi: Kielistetty, linja: Option[String]) =
+  def tallennettuLukioHakukohde(
+      oid: String,
+      toteutusOid: String,
+      hakuOid: String,
+      nimi: Kielistetty,
+      linja: Option[String]
+  ) =
     getIds(hakukohde(oid, toteutusOid, hakuOid)).copy(
       nimi = nimi,
       _enrichedData = Some(
@@ -147,7 +162,10 @@ trait HakukohdeFixture extends SQLHelpers with AccessControlSpec with ToteutusFi
       ),
       metadata = Some(
         hakukohde.metadata.get
-          .copy(hakukohteenLinja = Some(LukioHakukohteenLinja.copy(linja = linja)), valintaperusteenValintakokeidenLisatilaisuudet = Seq())
+          .copy(
+            hakukohteenLinja = Some(LukioHakukohteenLinja.copy(linja = linja)),
+            valintaperusteenValintakokeidenLisatilaisuudet = Seq()
+          )
       )
     )
 
@@ -246,8 +264,21 @@ trait HakukohdeFixture extends SQLHelpers with AccessControlSpec with ToteutusFi
   def put(hakukohteet: List[String], hakuOid: String): List[HakukohdeCopyResultObject] =
     put(s"$HakukohdeCopyPath$hakuOid", hakukohteet, listResponse[HakukohdeCopyResultObject])
 
-  def changeTila(hakukohteet: List[String], tila: String, lastModified: String, sessionId: UUID, expectedStatus: Int): List[HakukohdeTilaChangeResultObject] =
-    post(s"$HakukohdeChangeTilaPath$tila", hakukohteet, lastModified, sessionId, expectedStatus, listResponse[HakukohdeTilaChangeResultObject])
+  def changeTila(
+      hakukohteet: List[String],
+      tila: String,
+      lastModified: String,
+      sessionId: UUID,
+      expectedStatus: Int
+  ): List[HakukohdeTilaChangeResultObject] =
+    post(
+      s"$HakukohdeChangeTilaPath$tila",
+      hakukohteet,
+      lastModified,
+      sessionId,
+      expectedStatus,
+      listResponse[HakukohdeTilaChangeResultObject]
+    )
 
   def get(oid: String, expected: Hakukohde): String =
     get(HakukohdePath, oid, expected.copy(modified = Some(readHakukohdeModified(oid))))
@@ -281,6 +312,9 @@ trait HakukohdeFixture extends SQLHelpers with AccessControlSpec with ToteutusFi
     )
   }
 
+  def readHakukohdeMuokkaaja(oid: String): String = {
+    getStringColumnValue("hakukohteet", "muokkaaja", "oid", oid)
+  }
   def readHakukohdeModified(oid: String): Modified = readHakukohdeModified(HakukohdeOid(oid))
   def readHakukohdeModified(oid: HakukohdeOid): Modified =
     TimeUtils.instantToModifiedAt(db.runBlocking(HakukohdeDAO.selectLastModified(oid)).get)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
@@ -163,6 +163,11 @@ trait KoulutusDbFixture extends KoulutusExtractors with SQLHelpers {
     } yield n)
     .get
 
+  def getKoulutusMuokkaaja(k: Koulutus): String = {
+    val muokkaaja = getStringColumnValue("koulutukset", "muokkaaja", "oid", k.oid.get.toString)
+    getStringColumnValue("koulutukset", "muokkaaja", "oid", k.oid.get.toString)
+  }
+
   def getKoulutusHistorySize(k: Koulutus): Int = getTableHistorySize("koulutukset", "oid", k.oid.get.toString)
 
   def getKoulutusTarjoajatHistorySize(k: Koulutus): Int =

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/KoulutusFixture.scala
@@ -164,7 +164,6 @@ trait KoulutusDbFixture extends KoulutusExtractors with SQLHelpers {
     .get
 
   def getKoulutusMuokkaaja(k: Koulutus): String = {
-    val muokkaaja = getStringColumnValue("koulutukset", "muokkaaja", "oid", k.oid.get.toString)
     getStringColumnValue("koulutukset", "muokkaaja", "oid", k.oid.get.toString)
   }
 

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
@@ -142,7 +142,6 @@ trait ToteutusFixture extends KoulutusFixture with ToteutusDbFixture with Access
   }
 
   def readToteutusMuokkaaja(oid: String): String = {
-    val muokkaaja = getStringColumnValue("toteutukset", "muokkaaja", "oid", oid)
     getStringColumnValue("toteutukset", "muokkaaja", "oid", oid)
   }
   def readToteutusModified(oid: String): Modified = readToteutusModified(ToteutusOid(oid))

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/fixture/ToteutusFixture.scala
@@ -8,7 +8,13 @@ import fi.oph.kouta.domain.oid._
 import fi.oph.kouta.integration.{AccessControlSpec, DefaultMocks, KoutaIntegrationSpec}
 import fi.oph.kouta.mocks.{MockAuditLogger, MockS3ImageService}
 import fi.oph.kouta.repository.{HakukohdeDAO, KoulutusDAO, ToteutusExtractors, SQLHelpers, SorakuvausDAO, ToteutusDAO}
-import fi.oph.kouta.service.{KeywordService, OrganisaatioServiceImpl, ToteutusCopyResultObject, ToteutusService, ToteutusServiceValidation}
+import fi.oph.kouta.service.{
+  KeywordService,
+  OrganisaatioServiceImpl,
+  ToteutusCopyResultObject,
+  ToteutusService,
+  ToteutusServiceValidation
+}
 import fi.oph.kouta.servlet.ToteutusServlet
 import fi.oph.kouta.util.TimeUtils
 import fi.oph.kouta.{SqsInTransactionServiceIgnoringIndexing, TestData}
@@ -20,7 +26,7 @@ import scala.util.Try
 trait ToteutusFixture extends KoulutusFixture with ToteutusDbFixture with AccessControlSpec with DefaultMocks {
   this: KoutaIntegrationSpec =>
 
-  val ToteutusPath = "/toteutus"
+  val ToteutusPath     = "/toteutus"
   val ToteutusCopyPath = "/toteutus/copy"
 
   protected lazy val auditLog = new AuditLog(MockAuditLogger)
@@ -28,11 +34,28 @@ trait ToteutusFixture extends KoulutusFixture with ToteutusDbFixture with Access
   def toteutusService: ToteutusService = {
     val organisaatioService = new OrganisaatioServiceImpl(urlProperties.get)
     val lokalisointiClient  = new LokalisointiClient(urlProperties.get)
-    val koodistoClient = new CachedKoodistoClient(urlProperties.get)
-    val toteutusServiceValidation = new ToteutusServiceValidation(koodistoClient, organisaatioService, KoulutusDAO, HakukohdeDAO, SorakuvausDAO, ToteutusDAO)
-    new ToteutusService(SqsInTransactionServiceIgnoringIndexing, MockS3ImageService, auditLog,
-      new KeywordService(auditLog, organisaatioService), organisaatioService, koulutusService, lokalisointiClient,
-      koodistoClient, mockOppijanumerorekisteriClient, mockKayttooikeusClient, toteutusServiceValidation)
+    val koodistoClient      = new CachedKoodistoClient(urlProperties.get)
+    val toteutusServiceValidation = new ToteutusServiceValidation(
+      koodistoClient,
+      organisaatioService,
+      KoulutusDAO,
+      HakukohdeDAO,
+      SorakuvausDAO,
+      ToteutusDAO
+    )
+    new ToteutusService(
+      SqsInTransactionServiceIgnoringIndexing,
+      MockS3ImageService,
+      auditLog,
+      new KeywordService(auditLog, organisaatioService),
+      organisaatioService,
+      koulutusService,
+      lokalisointiClient,
+      koodistoClient,
+      mockOppijanumerorekisteriClient,
+      mockKayttooikeusClient,
+      toteutusServiceValidation
+    )
   }
 
   override def beforeAll(): Unit = {
@@ -40,37 +63,54 @@ trait ToteutusFixture extends KoulutusFixture with ToteutusDbFixture with Access
     addServlet(new ToteutusServlet(toteutusService), ToteutusPath)
   }
 
-  val opetus: Opetus = ToteutuksenOpetus
+  val opetus: Opetus                             = ToteutuksenOpetus
   val ammMetatieto: AmmatillinenToteutusMetadata = AmmToteutuksenMetatieto
-  val toteutus: Toteutus = JulkaistuAmmToteutus
-  val ammTutkinnonOsaToteutus: Toteutus = TestData.AmmTutkinnonOsaToteutus
-  val ammOsaamisalaToteutus: Toteutus = TestData.AmmOsaamisalaToteutus
-  val ammTutkinnonOsaToteutusAtaru: Toteutus = TestData.AmmTutkinnonOsaToteutus.copy(metadata = Some(TestData.AmmTutkinnonOsaToteutusMetadataHakemuspalvelu))
-  val ammOsaamisalaToteutusAtaru: Toteutus = TestData.AmmOsaamisalaToteutus.copy(metadata = Some(TestData.AmmOsaamisalaToteutusMetadataHakemuspalvelu))
+  val toteutus: Toteutus                         = JulkaistuAmmToteutus
+  val ammTutkinnonOsaToteutus: Toteutus          = TestData.AmmTutkinnonOsaToteutus
+  val ammOsaamisalaToteutus: Toteutus            = TestData.AmmOsaamisalaToteutus
+  val ammTutkinnonOsaToteutusAtaru: Toteutus =
+    TestData.AmmTutkinnonOsaToteutus.copy(metadata = Some(TestData.AmmTutkinnonOsaToteutusMetadataHakemuspalvelu))
+  val ammOsaamisalaToteutusAtaru: Toteutus =
+    TestData.AmmOsaamisalaToteutus.copy(metadata = Some(TestData.AmmOsaamisalaToteutusMetadataHakemuspalvelu))
   val vapaaSivistystyoMuuToteutus: Toteutus = TestData.VapaaSivistystyoMuuToteutus
-  val vapaaSivistystyoMuuToteutusAtaru: Toteutus = TestData.VapaaSivistystyoMuuToteutus.copy(metadata = Some(TestData.VapaaSivistystyoMuuToteutusHakemuspalveluMetatieto))
+  val vapaaSivistystyoMuuToteutusAtaru: Toteutus = TestData.VapaaSivistystyoMuuToteutus.copy(metadata =
+    Some(TestData.VapaaSivistystyoMuuToteutusHakemuspalveluMetatieto)
+  )
   val tuvaToteutus: Toteutus = TestData.TuvaToteutus
 
-  def toteutus(koulutusOid:String): Toteutus = toteutus.copy(koulutusOid = KoulutusOid(koulutusOid))
-  def toteutus(oid:String, koulutusOid:String): Toteutus = toteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid))
-  def toteutus(oid:String, koulutusOid:String, tila:Julkaisutila): Toteutus = toteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid), tila = tila)
+  def toteutus(koulutusOid: String): Toteutus = toteutus.copy(koulutusOid = KoulutusOid(koulutusOid))
+  def toteutus(oid: String, koulutusOid: String): Toteutus =
+    toteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid))
+  def toteutus(oid: String, koulutusOid: String, tila: Julkaisutila): Toteutus =
+    toteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid), tila = tila)
   def toteutus(koulutusOid: String, tila: Julkaisutila, organisaatioOid: OrganisaatioOid): Toteutus =
     toteutus.copy(koulutusOid = KoulutusOid(koulutusOid), organisaatioOid = organisaatioOid, tila = tila)
   def tuvaToteutus(koulutusOid: String): Toteutus = tuvaToteutus.copy(koulutusOid = KoulutusOid(koulutusOid))
-  def lukioToteutus(koulutusOid: String): Toteutus = LukioToteutus.copy(koulutusOid = KoulutusOid(koulutusOid), nimi = Map())
-  def toteutus(oid:String, koulutusOid:String, externalId: String): Toteutus = toteutus.copy(oid = Some(ToteutusOid(oid)), koulutusOid = KoulutusOid(koulutusOid), tila = Tallennettu, externalId = Some(externalId))
+  def lukioToteutus(koulutusOid: String): Toteutus =
+    LukioToteutus.copy(koulutusOid = KoulutusOid(koulutusOid), nimi = Map())
+  def toteutus(oid: String, koulutusOid: String, externalId: String): Toteutus = toteutus.copy(
+    oid = Some(ToteutusOid(oid)),
+    koulutusOid = KoulutusOid(koulutusOid),
+    tila = Tallennettu,
+    externalId = Some(externalId)
+  )
 
-  implicit val toteutusEquality: Equality[Toteutus] = (a: Toteutus, b: Any) => b match {
-    case _:Toteutus => Equality.default[Toteutus].areEqual(
-      a.copy(tarjoajat = a.tarjoajat.sorted),
-      b.asInstanceOf[Toteutus].copy(tarjoajat = b.asInstanceOf[Toteutus].tarjoajat.sorted)
-    )
-    case _ => false
-  }
+  implicit val toteutusEquality: Equality[Toteutus] = (a: Toteutus, b: Any) =>
+    b match {
+      case _: Toteutus =>
+        Equality
+          .default[Toteutus]
+          .areEqual(
+            a.copy(tarjoajat = a.tarjoajat.sorted),
+            b.asInstanceOf[Toteutus].copy(tarjoajat = b.asInstanceOf[Toteutus].tarjoajat.sorted)
+          )
+      case _ => false
+    }
 
-  def put(toteutus:Toteutus):String = put(ToteutusPath, toteutus, oid(_))
-  def put(toteutus:Toteutus, sessionId: UUID):String = put(ToteutusPath, toteutus, sessionId, oid(_))
-  def put(toteutukset: List[String]): List[ToteutusCopyResultObject] = put(ToteutusCopyPath, toteutukset, listResponse[ToteutusCopyResultObject])
+  def put(toteutus: Toteutus): String                  = put(ToteutusPath, toteutus, oid(_))
+  def put(toteutus: Toteutus, sessionId: UUID): String = put(ToteutusPath, toteutus, sessionId, oid(_))
+  def put(toteutukset: List[String]): List[ToteutusCopyResultObject] =
+    put(ToteutusCopyPath, toteutukset, listResponse[ToteutusCopyResultObject])
 
   def get(oid: String, expected: Toteutus): String =
     get(ToteutusPath, oid, expected.copy(modified = Some(readToteutusModified(oid))))
@@ -78,18 +118,33 @@ trait ToteutusFixture extends KoulutusFixture with ToteutusDbFixture with Access
   def get(oid: String, sessionId: UUID, expected: Toteutus): String =
     get(ToteutusPath, oid, sessionId, expected.copy(modified = Some(readToteutusModified(oid))))
 
-  def update(toteutus:Toteutus, lastModified:String, expectedStatus: Int, sessionId: UUID): Unit = update(ToteutusPath, toteutus, lastModified, sessionId, expectedStatus)
-  def update(toteutus:Toteutus, lastModified:String, expectUpdate:Boolean, sessionId: UUID): Unit = update(ToteutusPath, toteutus, lastModified, expectUpdate, sessionId)
-  def update(toteutus:Toteutus, lastModified:String, expectUpdate:Boolean): Unit = update(ToteutusPath, toteutus, lastModified, expectUpdate)
-  def update(toteutus:Toteutus, lastModified:String): Unit = update(toteutus, lastModified, expectUpdate = true)
+  def update(toteutus: Toteutus, lastModified: String, expectedStatus: Int, sessionId: UUID): Unit =
+    update(ToteutusPath, toteutus, lastModified, sessionId, expectedStatus)
+  def update(toteutus: Toteutus, lastModified: String, expectUpdate: Boolean, sessionId: UUID): Unit =
+    update(ToteutusPath, toteutus, lastModified, expectUpdate, sessionId)
+  def update(toteutus: Toteutus, lastModified: String, expectUpdate: Boolean): Unit =
+    update(ToteutusPath, toteutus, lastModified, expectUpdate)
+  def update(toteutus: Toteutus, lastModified: String): Unit = update(toteutus, lastModified, expectUpdate = true)
 
-  def addToList(toteutus:Toteutus): ToteutusListItem = {
-    val oid = put(toteutus)
+  def addToList(toteutus: Toteutus): ToteutusListItem = {
+    val oid      = put(toteutus)
     val modified = readToteutusModified(oid)
-    ToteutusListItem(ToteutusOid(oid), toteutus.koulutusOid, toteutus.nimi, toteutus.tila,
-      toteutus.tarjoajat, toteutus.organisaatioOid, toteutus.muokkaaja, modified)
+    ToteutusListItem(
+      ToteutusOid(oid),
+      toteutus.koulutusOid,
+      toteutus.nimi,
+      toteutus.tila,
+      toteutus.tarjoajat,
+      toteutus.organisaatioOid,
+      toteutus.muokkaaja,
+      modified
+    )
   }
 
+  def readToteutusMuokkaaja(oid: String): String = {
+    val muokkaaja = getStringColumnValue("toteutukset", "muokkaaja", "oid", oid)
+    getStringColumnValue("toteutukset", "muokkaaja", "oid", oid)
+  }
   def readToteutusModified(oid: String): Modified = readToteutusModified(ToteutusOid(oid))
   def readToteutusModified(oid: ToteutusOid): Modified =
     TimeUtils.instantToModifiedAt(db.runBlocking(ToteutusDAO.selectLastModified(oid)).get)

--- a/kouta-backend/src/test/scala/fi/oph/kouta/mocks/MockKayttooikeusClient.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/mocks/MockKayttooikeusClient.scala
@@ -15,7 +15,7 @@ class MockKayttooikeusClient(securityContext: SecurityContext, defaultAuthoritie
 
   override def getOrganisaatiotFromCache(oid: UserOid): List[OrganisaatioHenkilo] = {
     val organisaatiot = List(OrganisaatioHenkilo(GrandChildOid.s), OrganisaatioHenkilo(EvilCousin.s))
-    if (oid.equals(OphUserOid)) {
+    if (oid.equals(OphUserOid) || oid.equals(OphUserOid2)) {
       OrganisaatioHenkilo(OphOid.s) :: organisaatiot
     } else {
       organisaatiot

--- a/kouta-common/src/test/scala/fi/oph/kouta/TestOids.scala
+++ b/kouta-common/src/test/scala/fi/oph/kouta/TestOids.scala
@@ -35,6 +35,7 @@ object TestOids {
 
   val TestUserOid = UserOid("1.2.246.562.24.10000000000")
   val OphUserOid = UserOid("1.2.246.562.24.10000000099")
+  val OphUserOid2 = UserOid("1.2.246.562.24.10000000098")
 
   val random = new Random()
 


### PR DESCRIPTION
Koulutuksen tarjoajan, toteutuksen tarjoajan, haun hakuajan, valintaperusteiden valintakokeiden, hakukohteen hakuajan/liitteiden/valintakokeiden muokkaaminen päivittää muokkaaja-tiedon (ja aikaleiman) pääentiteetille.
Samalla hieman paranneltu joitain liitännäisten päivityksiä niin ettei tule turhia operaatioita.