### PR TITLE
Oy 4551 datasiivous

### DIFF
--- a/kouta-backend/src/main/resources/db/migration/V123__migrate_hakeutumistiedot.sql
+++ b/kouta-backend/src/main/resources/db/migration/V123__migrate_hakeutumistiedot.sql
@@ -6,7 +6,7 @@ where toteutus_oid in (select t.oid
                             koulutukset k,
                             hakukohteet h
                        where k.tyyppi in ('kk-opintojakso', 'kk-opintokokonaisuus')
-                         and t.metadata::jsonb ->> 'hakulomaketyyppi' in ('muu', 'ei  sähköistä')
+                         and t.metadata::jsonb ->> 'hakulomaketyyppi' in ('muu', 'ei sähköistä')
                          and t.oid = h.toteutus_oid
                          and t.koulutus_oid = k.oid
                          and t.tila <> 'poistettu'
@@ -20,6 +20,14 @@ set metadata = jsonb_set(metadata, '{isHakukohteetKaytossa}', 'true', TRUE)
 where t.metadata::jsonb ->> 'hakulomaketyyppi' = 'ataru'
   and t.metadata::jsonb ->> 'isHakukohteetKaytossa' is null
   and t.oid in (select toteutus_oid from hakukohteet)
+  and t.tila<>'poistettu' and t.tila<>'arkistoitu';
+
+-- hakukohteet käytössä -tieto toteutuksille joilla ei ole hakukohteet käytössä
+update toteutukset t
+set metadata = jsonb_set(metadata, '{isHakukohteetKaytossa}', 'false', TRUE)
+where t.metadata::jsonb ->> 'hakulomaketyyppi' in ('muu', 'ei sähköistä')
+  and t.metadata::jsonb ->> 'isHakukohteetKaytossa' is null
+  and t.oid not in (select toteutus_oid from hakukohteet)
   and t.tila<>'poistettu' and t.tila<>'arkistoitu';
 
 -- siivotaan aloituspaikkatieto toteutuksilta jos tieto on hakukohteella

--- a/kouta-backend/src/main/resources/db/migration/V124__migrate_hakeutumistiedot.sql
+++ b/kouta-backend/src/main/resources/db/migration/V124__migrate_hakeutumistiedot.sql
@@ -26,4 +26,5 @@ where t.metadata::jsonb ->> 'hakulomaketyyppi' = 'ataru'
 update toteutukset t
 set metadata = metadata - 'aloituspaikat'
 where t.metadata->'aloituspaikat' is not null
+  and t.tila<>'poistettu'
   and t.oid in (select toteutus_oid from hakukohteet where metadata->'aloituspaikat' -> 'lukumaara' is not null);

--- a/kouta-backend/src/main/resources/db/migration/V124__migrate_hakeutumistiedot.sql
+++ b/kouta-backend/src/main/resources/db/migration/V124__migrate_hakeutumistiedot.sql
@@ -1,0 +1,23 @@
+-- luonnostilaiset hakukohteet poistetaan
+update hakukohteet
+set tila = 'poistettu'
+where toteutus_oid in (select t.oid
+                       from toteutukset t,
+                            koulutukset k,
+                            hakukohteet h
+                       where k.tyyppi in ('kk-opintojakso', 'kk-opintokokonaisuus')
+                         and t.metadata::jsonb ->> 'hakulomaketyyppi' in ('muu', 'ei  sähköistä')
+                         and t.oid = h.toteutus_oid
+                         and t.koulutus_oid = k.oid
+                         and t.tila <> 'poistettu'
+                         and t.tila <> 'arkistoitu'
+                         and h.tila = 'tallennettu'
+                         and t.oid in (select new_oid from migration_old_to_new_oid_lookup));
+
+-- lisätään hakukohteet käytössä -tieto toteutuksille joilla on hakukohteet käytössä
+update toteutukset t
+set metadata = jsonb_set(metadata, '{isHakukohteetKaytossa}', 'true', TRUE)
+where t.metadata::jsonb ->> 'hakulomaketyyppi' = 'ataru'
+  and t.metadata::jsonb ->> 'isHakukohteetKaytossa' is null
+  and t.oid in (select toteutus_oid from hakukohteet)
+  and t.tila<>'poistettu' and t.tila<>'arkistoitu'


### PR DESCRIPTION
Migratoidut toteutukset joiden koulutustyyppi on kk-opintojakso tai kk-opintokokonaisuus ja tila ei arkistoitu/poistettu:
jos toteutuksen hakulomaketyyppi on 'muu'/'ei sähköistä' ja on kiinnitettynä luonnostilaisia hakukohteita, muutetaan hakukohteet tilaan 'poistettu'.

Jos toteutuksella on valittuna hakulomaketyypiksi hakemuspalvelu ja kiinnitettynä hakukohteita, päivitetään metadataan hakukohteet käytössä -kenttään arvo 'kyllä'.

Siivotaan aloituspaikkatieto toteutuksella, jos sekä toteutuksella että hakukohteella löytyy aloituspaikkojen lukumäärä.