### PR TITLE
OY-5021: Urheilijoiden ammatillisen koulutuksen järjestämiseen liittyvän tiedon näkyminen hakukohteella

### DIFF
--- a/kouta-backend/src/main/scala/fi/oph/kouta/client/OrganisaatioServiceClient.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/client/OrganisaatioServiceClient.scala
@@ -87,15 +87,6 @@ class OrganisaatioServiceClient extends HttpClient with CallerId with Logging wi
     }
   }
 
-  def getOrganisaatioHierarkiaWithOidsFromCache(oids: Seq[OrganisaatioOid]): OrganisaatioHierarkia = {
-    organisaatioHierarkiaWithOidsCache.get(
-      oids,
-      oids => {
-        getOrganisaatioHierarkia(OrganisaatioHierarkiaQueryParams(oids))
-      }
-    )
-  }
-
   def getOrganisaatioHierarkiaFromCache(
       params: Option[Params],
       multiParams: Option[MultiParams],

--- a/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutus.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/domain/toteutus.scala
@@ -168,6 +168,14 @@ package object toteutus {
       |           format: date-time
       |           description: Toteutuksen viimeisin muokkausaika. Järjestelmän generoima
       |           example: 2019-08-23T09:55:17
+      |        koulutuksetKoodiUri:
+      |          type: array
+      |          description: Koulutuksen koodi URIt. Viittaa [koodistoon](https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodisto/koulutus/11)
+      |          items:
+      |            type: string
+      |          example:
+      |            - koulutus_371101#1
+      |            - koulutus_201001#1
       |""".stripMargin
 
   val ToteutusListItemModel =

--- a/kouta-backend/src/main/scala/fi/oph/kouta/util/OrganisaatioServiceUtil.scala
+++ b/kouta-backend/src/main/scala/fi/oph/kouta/util/OrganisaatioServiceUtil.scala
@@ -1,5 +1,6 @@
 package fi.oph.kouta.util
 
+import fi.oph.kouta.client.OidAndChildren
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid.OrganisaatioOid
 
@@ -127,6 +128,29 @@ object OrganisaatioServiceUtil {
       oppilaitostyyppiUri = getOppilaitostyyppiUri(organisaatio),
       kieletUris = organisaatio.kieletUris,
       organisaatiotyyppiUris = getOrganisaatiotyyppiUris(organisaatio)
+    )
+  }
+
+  def oidAndChildrenToOrganisaatio(oidAndChildren: OidAndChildren): Organisaatio = {
+    val parentOids = getParentOids(oidAndChildren.parentOidPath)
+    Organisaatio(
+      oid = oidAndChildren.oid.toString,
+      parentOid = parentOids.lastOption,
+      parentOids = parentOids,
+      nimi = oidAndChildren.nimi.map{ case (k, nimi) =>
+       k match {
+         case "fi" => (Fi, nimi)
+         case "sv" => (Sv, nimi)
+         case "en" => (En, nimi)
+         case _ => throw new IllegalArgumentException(s"Unknown language code: $k")
+       }},
+      kieletUris = List(),
+      yhteystiedot = None,
+      status = oidAndChildren.status,
+      kotipaikkaUri = None,
+      children = Option(oidAndChildren.children.map(oidAndChildrenToOrganisaatio)),
+      oppilaitostyyppiUri = oidAndChildren.oppilaitostyyppi.map(MiscUtils.withoutKoodiVersion),
+      organisaatiotyyppiUris = Option(oidAndChildren.organisaatiotyypit.map(MiscUtils.withoutKoodiVersion))
     )
   }
 }

--- a/kouta-backend/src/test/scala/fi/oph/kouta/integration/OppilaitosSpec.scala
+++ b/kouta-backend/src/test/scala/fi/oph/kouta/integration/OppilaitosSpec.scala
@@ -11,6 +11,8 @@ import fi.oph.kouta.mocks.MockAuditLogger
 import fi.oph.kouta.security.Role
 import fi.oph.kouta.servlet.KoutaServlet
 import fi.oph.kouta.validation.Validations._
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.Serialization.read
 
 import java.time.LocalDateTime
@@ -30,16 +32,16 @@ class OppilaitosSpec extends KoutaIntegrationSpec with AccessControlSpec with Op
     List(
       Organisaatio(
         oid,
-        Some(OrganisaatioOid("1.2.246.562.10.47941294986")),
-        List(OrganisaatioOid(oid), OrganisaatioOid("1.2.246.562.10.47941294986"), OrganisaatioOid("1.2.246.562.10.00000000001")),
-        Map(Fi -> "Opisto fi", Sv -> "Opisto sv", En -> "Opisto en"),
+        parentOid = Some(OrganisaatioOid("1.2.246.562.10.47941294986")),
+        parentOids = List(OrganisaatioOid(oid), OrganisaatioOid("1.2.246.562.10.47941294986"), OrganisaatioOid("1.2.246.562.10.00000000001")),
+        nimi = Map(Fi -> "Opisto fi", Sv -> "Opisto sv", En -> "Opisto en"),
         kieletUris = List(),
         yhteystiedot = None,
         status = "AKTIIVINEN",
         kotipaikkaUri = None,
         children = None,
         oppilaitostyyppiUri = Some("oppilaitostyyppi_63#1"),
-        Some(List("organisaatiotyyppi_02")))))
+        organisaatiotyyppiUris = Some(List("organisaatiotyyppi_02")))))
 
   val notSavedInKoutaOrgOid = OrganisaatioOid("1.2.246.562.10.404")
 
@@ -606,30 +608,49 @@ class OppilaitosSpec extends KoutaIntegrationSpec with AccessControlSpec with Op
       logo = Some(s"$PublicImageServer/temp/logo.png")
     )
     update(oppilaitosWithImages, lastModified1)
-
     get(oid2, createdOppilaitos2)
   }
 
   "Get oppilaitokset by oids" should "not return oppilaitos data for oppilaitos not in kouta" in {
-    val organisaatioServiceHierarkia = organisaatioHierarkia(UnknownOid.toString)
-    when(mockOrganisaatioServiceClient.getOrganisaatioHierarkiaWithOidsFromCache(List(UnknownOid))).thenReturn(organisaatioServiceHierarkia)
-    when(mockOppilaitosDao.get(List(UnknownOid))).thenReturn(Vector())
-    post(s"$OppilaitosPath/oppilaitokset", bytes(List(UnknownOid)), headers = defaultHeaders) {
+    // organisaatiot (jalkelaiset-rajapinta) alustettu organisaatio.json-tiedostosta (OrganisaatioServiceMock)
+    val unknownOid = HkiYoOid
+    when(mockOppilaitosDao.get(List(unknownOid))).thenReturn(Vector())
+    post(s"$OppilaitosPath/oppilaitokset", bytes(List(unknownOid)), headers = defaultHeaders) {
       status should equal (200)
       body should include ("{\"oppilaitokset\":[]")
+      val parsedBody = JsonMethods.parse(body)
+      val oppilaitokset = (parsedBody \ "oppilaitokset").extract[List[JValue]]
+      oppilaitokset should have size 0
+      val organisaatiot = (parsedBody \ "organisaatioHierarkia" \ "organisaatiot").extract[List[JValue]]
+      organisaatiot should have size 1
+      val organisaatio = organisaatiot.head
+      (organisaatio \ "oid").extract[String] should equal(unknownOid.toString)
     }
   }
 
-  it should "succeed in sending oppilaitos data for existing oppilaitos" in {
-    val oid = put(oppilaitos)
-    val organisaatioServiceHierarkia = organisaatioHierarkia(oid)
-    when(mockOrganisaatioServiceClient.getOrganisaatioHierarkiaWithOidsFromCache(List(OrganisaatioOid(oid)))).thenReturn(organisaatioServiceHierarkia)
-    when(mockOppilaitosDao.get(List(OrganisaatioOid(oid)))).thenReturn(
-      Vector(OppilaitosAndOsa(oppilaitos = oppilaitos.copy(oid = OrganisaatioOid(oid)), osa = Some(oppilaitoksenOsa))))
-
-    post(s"$OppilaitosPath/oppilaitokset", bytes(List(oid)), headers = defaultHeaders) {
+  it should "succeed in returning oppilaitos data for existing oppilaitos" in {
+    // organisaatiot (jalkelaiset-rajapinta) alustettu organisaatio.json-tiedostosta (OrganisaatioServiceMock)
+    val oppilaitosOid = HkiYoOid
+    val toimipisteOid = "1.2.246.562.10.27277224708" // Helsingin yliopisto, Lääketieteellinen tiedekunta, Ammatillinen jatkokoulutus
+    when(mockOppilaitosDao.get(List(oppilaitosOid))).thenReturn(
+      Vector(OppilaitosAndOsa(oppilaitos = oppilaitos.copy(oid = oppilaitosOid),
+                              osa = Some(oppilaitoksenOsa(toimipisteOid)))))
+    post(s"$OppilaitosPath/oppilaitokset", bytes(List(toimipisteOid)), headers = defaultHeaders) {
       status should equal (200)
-      body should include (s"""{\"oppilaitokset\":[{\"oid\":\"$oid\"""")
+      val parsedBody = JsonMethods.parse(body)
+      val oppilaitokset = (parsedBody \ "oppilaitokset").extract[List[JValue]]
+      oppilaitokset should have size 1
+      val oppilaitos = oppilaitokset.head
+      (oppilaitos \ "oid").extract[String] should equal(oppilaitosOid.toString)
+      val osat = (oppilaitos \ "osat").extract[List[JValue]]
+      osat should have size 1
+      val osa = osat.head
+      (osa \ "oid").extract[String] should equal(toimipisteOid)
+
+      val organisaatiot = (parsedBody \ "organisaatioHierarkia" \ "organisaatiot").extract[List[JValue]]
+      organisaatiot should have size 1
+      val organisaatio = organisaatiot.head
+      (organisaatio \ "oid").extract[String] should equal(oppilaitosOid.toString)
     }
   }
 }

--- a/kouta-common/src/main/scala/fi/oph/kouta/client/organisaatioClient.scala
+++ b/kouta-common/src/main/scala/fi/oph/kouta/client/organisaatioClient.scala
@@ -29,6 +29,7 @@ trait CachedOrganisaatioHierarkiaClient extends HttpClient with GenericKoutaJson
 case class OrganisaatioResponse(numHits: Int, organisaatiot: List[OidAndChildren])
 
 case class OidAndChildren(oid: OrganisaatioOid,
+                          nimi: Map[String, String] = Map(),
                           children: List[OidAndChildren],
                           parentOidPath: String,
                           oppilaitostyyppi: Option[String],

--- a/kouta-common/src/main/scala/fi/oph/kouta/service/OrganisaatioService.scala
+++ b/kouta-common/src/main/scala/fi/oph/kouta/service/OrganisaatioService.scala
@@ -62,6 +62,7 @@ trait OrganisaatioService {
     Try[OidAndChildren] {
       OidAndChildren(
         RootOrganisaatioOid,
+        Map("fi" -> "Opetushallitus"),
         cachedOrganisaatioHierarkiaClient.getWholeOrganisaatioHierarkiaCached().organisaatiot,
         RootOrganisaatioOid.s,
         None,
@@ -95,10 +96,10 @@ trait OrganisaatioService {
       .getOrElse(Seq())
   }
   private def oppilaitostyypitToKoulutustyypit(oppilaitostyypit: Seq[String]) =
-    oppilaitostyypit.map(Koulutustyyppi.fromOppilaitostyyppi).flatten.distinct
+    oppilaitostyypit.flatMap(Koulutustyyppi.fromOppilaitostyyppi).distinct
 
   @tailrec
-  private def find(pred: OidAndChildren => Boolean, level: Set[OidAndChildren]): Option[OidAndChildren] =
+  protected final def find(pred: OidAndChildren => Boolean, level: Set[OidAndChildren]): Option[OidAndChildren] =
     level.find(pred) match {
       case None if level.isEmpty => None
       case Some(c)               => Some(c)


### PR DESCRIPTION
Muutettu `/oppilaitos/oppilaitokset`-rajapintaa siten, että haetaan tiedot aina myös toimispisteitä vastaaville oppilaitoksille, vaikka toimipistettä ei olisi tallennettu koutaan. Vaihdettu kutsu käyttämään "jalkelaiset"-rajapinnasta haettua koko hierarkiaa, koska organisaatio-palvelun `/hierarkia/hae`-rajapinta ei palauta organisaatioiden vanhempia kun sille annetaan `oidRestrictionList`-parametri, vaikka lisäksi annettaisiin `skipParents=false`.